### PR TITLE
Added ability for sage specific user-agent

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,3 +7,4 @@
 # The email address is not required for organizations.
 
 Google Inc.
+Christopher Piper <fuzzy@weirdness.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -17,3 +17,4 @@ Niel Markwick <nielm@google.com>
 David DeHaven <daved@bacomatic.org>
 Brian Russell <i601@me.com>
 John McDole <codefu@google.com>
+Christopher Piper <fuzzy@weirdness.com>

--- a/java/sage/FileDownloader.java
+++ b/java/sage/FileDownloader.java
@@ -184,6 +184,8 @@ public class FileDownloader extends SystemTask
           myURLConn = myURL.openConnection();
           if (httpRangeSupported)
             myURLConn.setRequestProperty("Range", "bytes=0-");
+          if (sage.getBoolean("use_sagetv_user_agent", false))
+            myURLConn.setRequestProperty("User-Agent", "SageTV/" + sage.Version.MAJOR_VERSION + "." + sage.Version.MINOR_VERSION + "." + sage.Version.MICRO_VERSION);
           if (requestProps != null)
           {
             java.util.Iterator walker = requestProps.entrySet().iterator();


### PR DESCRIPTION
Added the ability for sage to set a default user-agent string of "SageTV/x.x.x" for file downloads.  Will only set the new string when property "use_sagetv_user_agent" is set to true, otherwise it will remain the default "Java/x.x.x_xx".

PULL REQUEST NOTE:  This is a partial, yet standalone fix for Issue #2.