### PR TITLE
add initial .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# Lines that start with '#' are comments.
+*~
+config*.log
+
+# taken from build/clean.sh
+/build/so
+/build/release
+/build/minirelease
+/build/elf
+/build/serverrelease
+/build/ubuntuserver
+/build/ubuntuclient
+/build/clientrelease
+/build/sagetv*.deb
+/build/sagetv*.gz
+
+/native/**/*.o
+/native/**/*.map
+/native/**/*.a
+/native/**/*.so
+
+/third_party/**/*.o
+/third_party/**/*.lo
+/third_party/**/*.la
+/third_party/**/*.pc


### PR DESCRIPTION
After the linux build git shows 1900+ untracked files. This commit
adds a top level .gitignore file to address the low hanging fruits
first. It shrinks the untracked files down to about 270.

The remaining ones are in third_party/ and would need more selective
pruning.

Tested by searching for specified pattern in a clean sagetv repo and
no files were found.