### PR TITLE
Fixes for hard-coded values and Java dependencies in the Ubuntu build.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,3 +8,4 @@
 
 Google Inc.
 Christopher Piper <fuzzy@weirdness.com>
+Jason Reicheneker <jason.reicheneker@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -18,3 +18,4 @@ David DeHaven <daved@bacomatic.org>
 Brian Russell <i601@me.com>
 John McDole <codefu@google.com>
 Christopher Piper <fuzzy@weirdness.com>
+Jason Reicheneker <jason.reicheneker@gmail.com>

--- a/build/buildubuntu.sh
+++ b/build/buildubuntu.sh
@@ -19,6 +19,11 @@ MAJOR_VERSION=`grep MAJOR_VERSION ../java/sage/Version.java | grep -o [0-9]*`
 MINOR_VERSION=`grep MINOR_VERSION ../java/sage/Version.java | grep -o [0-9]*`
 MICRO_VERSION=`grep MICRO_VERSION ../java/sage/Version.java | grep -o [0-9]*`
 
+# Get the architecture, if not already set
+if [ -z "$DEB_ARCH" ]; then
+  DEB_ARCH=`dpkg --print-architecture`
+fi
+
 echo Building server package
 rm -rf ubuntuserver
 mkdir ubuntuserver
@@ -29,7 +34,11 @@ mkdir ubuntuserver/opt/sagetv
 mkdir ubuntuserver/opt/sagetv/server
 cp -R serverrelease/* ubuntuserver/opt/sagetv/server/
 chmod -R 755 ubuntuserver
-dpkg -b ubuntuserver sagetv-server_"$MAJOR_VERSION"."$MINOR_VERSION"."$MICRO_VERSION"_i386.deb
+sed -i "s/MAJOR_VERSION/$MAJOR_VERSION/g" ubuntuserver/DEBIAN/control
+sed -i "s/MINOR_VERSION/$MINOR_VERSION/g" ubuntuserver/DEBIAN/control
+sed -i "s/MICRO_VERSION/$MICRO_VERSION/g" ubuntuserver/DEBIAN/control
+sed -i "s/DEB_ARCH/$DEB_ARCH/g" ubuntuserver/DEBIAN/control
+dpkg -b ubuntuserver sagetv-server_"$MAJOR_VERSION"."$MINOR_VERSION"."$MICRO_VERSION"_"$DEB_ARCH".deb
 
 echo Building client package
 rm -rf ubuntuclient
@@ -40,5 +49,11 @@ mkdir ubuntuclient/opt/sagetv
 mkdir ubuntuclient/opt/sagetv/client
 cp -R clientrelease/* ubuntuclient/opt/sagetv/client/
 chmod -R 755 ubuntuclient
-dpkg -b ubuntuclient sagetv-client_"$MAJOR_VERSION"."$MINOR_VERSION"."$MICRO_VERSION"_i386.deb
-
+sed -i "s/MAJOR_VERSION/$MAJOR_VERSION/g" ubuntuclient/DEBIAN/control
+sed -i "s/MINOR_VERSION/$MINOR_VERSION/g" ubuntuclient/DEBIAN/control
+sed -i "s/MICRO_VERSION/$MICRO_VERSION/g" ubuntuclient/DEBIAN/control
+sed -i "s/DEB_ARCH/$DEB_ARCH/g" ubuntuclient/DEBIAN/control
+sed -i "s/MAJOR_VERSION/$MAJOR_VERSION/g" ubuntuclient/usr/share/applications/sagetv.desktop
+sed -i "s/MINOR_VERSION/$MINOR_VERSION/g" ubuntuclient/usr/share/applications/sagetv.desktop
+sed -i "s/MICRO_VERSION/$MICRO_VERSION/g" ubuntuclient/usr/share/applications/sagetv.desktop
+dpkg -b ubuntuclient sagetv-client_"$MAJOR_VERSION"."$MINOR_VERSION"."$MICRO_VERSION"_"$DEB_ARCH".deb

--- a/build/ubuntufiles/client/DEBIAN/control
+++ b/build/ubuntufiles/client/DEBIAN/control
@@ -5,5 +5,5 @@ Installed-Size: 13840
 Maintainer: jeanfrancois@sagetv.com
 Architecture: DEB_ARCH
 Version: MAJOR_VERSION.MINOR_VERSION.MICRO_VERSION
-Depends: libasound2, sun-java6-jre, libfaac0
+Depends: libasound2, java5-runtime | java5-sdk, libfaac0
 Description: SageTV Client MAJOR_VERSION.MINOR_VERSION.MICRO_VERSION

--- a/build/ubuntufiles/client/DEBIAN/control
+++ b/build/ubuntufiles/client/DEBIAN/control
@@ -3,7 +3,7 @@ Priority: extra
 Section: base
 Installed-Size: 13840
 Maintainer: jeanfrancois@sagetv.com
-Architecture: i386
-Version: 6.5.8-1
+Architecture: DEB_ARCH
+Version: MAJOR_VERSION.MINOR_VERSION.MICRO_VERSION
 Depends: libasound2, sun-java6-jre, libfaac0
-Description: SageTV Client 6.5.8
+Description: SageTV Client MAJOR_VERSION.MINOR_VERSION.MICRO_VERSION

--- a/build/ubuntufiles/client/usr/share/applications/sagetv.desktop
+++ b/build/ubuntufiles/client/usr/share/applications/sagetv.desktop
@@ -1,8 +1,8 @@
 [Desktop Entry]
 Encoding=UTF-8
 Type=Application
-Name=SageTV Client 6.5.8
-Comment=Client/Placeshifter for SageTV 6.5.8
+Name=SageTV Client MAJOR_VERSION.MINOR_VERSION.MICRO_VERSION
+Comment=Client/Placeshifter for SageTV MAJOR_VERSION.MINOR_VERSION.MICRO_VERSION
 Exec=/opt/sagetv/client/sageclient.sh
 TryExec=/opt/sagetv/client/sageclient.sh
 Terminal=false

--- a/build/ubuntufiles/server/DEBIAN/control
+++ b/build/ubuntufiles/server/DEBIAN/control
@@ -3,8 +3,8 @@ Priority: extra
 Section: base
 Installed-Size: 33308
 Maintainer: jeanfrancois@sagetv.com
-Architecture: i386
-Version: 6.5.8-1
+Architecture: DEB_ARCH
+Version: MAJOR_VERSION.MINOR_VERSION.MICRO_VERSION
 Depends: sun-java6-jre
 Suggests: ivtv
-Description: SageTV Server 6.5.8
+Description: SageTV Server MAJOR_VERSION.MINOR_VERSION.MICRO_VERSION

--- a/build/ubuntufiles/server/DEBIAN/control
+++ b/build/ubuntufiles/server/DEBIAN/control
@@ -5,6 +5,6 @@ Installed-Size: 33308
 Maintainer: jeanfrancois@sagetv.com
 Architecture: DEB_ARCH
 Version: MAJOR_VERSION.MINOR_VERSION.MICRO_VERSION
-Depends: sun-java6-jre
+Depends: java5-runtime | java5-sdk
 Suggests: ivtv
 Description: SageTV Server MAJOR_VERSION.MINOR_VERSION.MICRO_VERSION


### PR DESCRIPTION
* Put the correct architecture in the .deb filename
* Put version and architecture into .deb control files at build-time
* Put version and architecture into the sagetv.desktop file at build-time
* Change the .deb Java dependency from Sun's v6 JRE, to any JDK or JRE v5 or higher (I think I saw in the forums that the minimum is 5)