### PR TITLE
Trim string created from reading activkey file

### DIFF
--- a/java/sage/WarlockRipper.java
+++ b/java/sage/WarlockRipper.java
@@ -234,7 +234,7 @@ public class WarlockRipper extends EPGDataSource
   }
 
   public static String getEPGLicenseKey() {
-    return Sage.WINDOWS_OS ? System.getProperty("USERKEY") : IOUtils.getFileAsString(new java.io.File("activkey"));
+    return Sage.WINDOWS_OS ? System.getProperty("USERKEY") : IOUtils.getFileAsString(new java.io.File("activkey")).trim();
   }
 
   public static boolean doesHaveEpgLicense() {


### PR DESCRIPTION
Whitespace characters were not being stripped when reading activkey file resulting in an inability to connect to EPG server.