### PR TITLE
Fix linker error for dvbtest

### DIFF
--- a/native/so/DVBCapture2.0/Makefile
+++ b/native/so/DVBCapture2.0/Makefile
@@ -40,8 +40,8 @@ libDVBCapture.so: $(OBJFILES)
 libDVBCapture.so.debug: $(OBJFILES) 
 	$(CC) -g -O0 -Wl,-Map=libDVBCapture.map -shared -W1 -o libDVBCapture.so libNativeCored.so $(OBJFILES)  $(CHANNELD_LIB)
 
-dvbtest: dep_make libDVBCapture.so dvbtest.o sage_DVBCaptureDevice.c
-	$(CC)   -Wall -o dvbtest dvbtest.o libNativeCore.so  $(CHANNEL_LIB)
+dvbtest: dep_make libDVBCapture.so dvbtest.o
+	$(CC) -pthread -Wall -o dvbtest dvbtest.o libNativeCore.so circbuffer.o thread_util.o $(CHANNEL_LIB)
 
 dvbtest.o: sage_DVBCaptureDevice.c
 	$(CC) $(CFLAGS) -c -o dvbtest.o -DSTANDALONE sage_DVBCaptureDevice.c		


### PR DESCRIPTION
Also clean up unnecessary dependencies.

Here are the linker errors this fixes:

gcc   -Wall -o dvbtest dvbtest.o libNativeCore.so  ../../lib/NativeCore/channel.a
dvbtest.o: In function `Java_sage_DVBCaptureDevice_createEncoder0':
/files/sagetv-master/native/so/DVBCapture2.0/sage_DVBCaptureDevice.c:331: undefined reference to `createCircBuffer'
/files/sagetv-master/native/so/DVBCapture2.0/sage_DVBCaptureDevice.c:343: undefined reference to `ACL_CreateMutex'
dvbtest.o: In function `Java_sage_DVBCaptureDevice_setupEncoding0':
/files/sagetv-master/native/so/DVBCapture2.0/sage_DVBCaptureDevice.c:610: undefined reference to `resetCircBuffer'
/files/sagetv-master/native/so/DVBCapture2.0/sage_DVBCaptureDevice.c:611: undefined reference to `ACL_CreateThread'
dvbtest.o: In function `Java_sage_DVBCaptureDevice_closeEncoding0':
/files/sagetv-master/native/so/DVBCapture2.0/sage_DVBCaptureDevice.c:714: undefined reference to `ACL_LockMutex'
/files/sagetv-master/native/so/DVBCapture2.0/sage_DVBCaptureDevice.c:716: undefined reference to `ACL_UnlockMutex'
/files/sagetv-master/native/so/DVBCapture2.0/sage_DVBCaptureDevice.c:718: undefined reference to `ACL_ThreadJoin'
/files/sagetv-master/native/so/DVBCapture2.0/sage_DVBCaptureDevice.c:720: undefined reference to `ACL_RemoveThread'
dvbtest.o: In function `Java_sage_DVBCaptureDevice_destroyEncoder0':
/files/sagetv-master/native/so/DVBCapture2.0/sage_DVBCaptureDevice.c:755: undefined reference to `ACL_LockMutex'
/files/sagetv-master/native/so/DVBCapture2.0/sage_DVBCaptureDevice.c:757: undefined reference to `ACL_UnlockMutex'
/files/sagetv-master/native/so/DVBCapture2.0/sage_DVBCaptureDevice.c:759: undefined reference to `ACL_ThreadJoin'
/files/sagetv-master/native/so/DVBCapture2.0/sage_DVBCaptureDevice.c:761: undefined reference to `ACL_RemoveThread'
/files/sagetv-master/native/so/DVBCapture2.0/sage_DVBCaptureDevice.c:819: undefined reference to `ACL_RemoveMutex'
dvbtest.o: In function `CaptureThread':
/files/sagetv-master/native/so/DVBCapture2.0/sage_DVBCaptureDevice.c:842: undefined reference to `ACL_LockMutex'
/files/sagetv-master/native/so/DVBCapture2.0/sage_DVBCaptureDevice.c:844: undefined reference to `ACL_UnlockMutex'
/files/sagetv-master/native/so/DVBCapture2.0/sage_DVBCaptureDevice.c:861: undefined reference to `ACL_LockMutex'
/files/sagetv-master/native/so/DVBCapture2.0/sage_DVBCaptureDevice.c:863: undefined reference to `freespaceCircBuffer'
/files/sagetv-master/native/so/DVBCapture2.0/sage_DVBCaptureDevice.c:871: undefined reference to `freespaceCircBuffer'
/files/sagetv-master/native/so/DVBCapture2.0/sage_DVBCaptureDevice.c:874: undefined reference to `addCircBuffer'
/files/sagetv-master/native/so/DVBCapture2.0/sage_DVBCaptureDevice.c:893: undefined reference to `ACL_UnlockMutex'
dvbtest.o: In function `Java_sage_DVBCaptureDevice_eatEncoderData0':
/files/sagetv-master/native/so/DVBCapture2.0/sage_DVBCaptureDevice.c:974: undefined reference to `ACL_LockMutex'
/files/sagetv-master/native/so/DVBCapture2.0/sage_DVBCaptureDevice.c:975: undefined reference to `usedspaceCircBuffer'
/files/sagetv-master/native/so/DVBCapture2.0/sage_DVBCaptureDevice.c:977: undefined reference to `getCircBuffer'
/files/sagetv-master/native/so/DVBCapture2.0/sage_DVBCaptureDevice.c:978: undefined reference to `ACL_UnlockMutex'
/files/sagetv-master/native/so/DVBCapture2.0/sage_DVBCaptureDevice.c:981: undefined reference to `ACL_Delay'
collect2: error: ld returned 1 exit status