### PR TITLE
update libhdhomerun to 20150615

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ config*.log
 /bin/
 /.classpath
 /.project
+/.cproject
 /.gradle/
 /.settings/
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -21,3 +21,4 @@ Christopher Piper <fuzzy@weirdness.com>
 Jason Reicheneker <jason.reicheneker@gmail.com>
 Raymond Chi <raychi@gmail.com>
 Joshua Lewis <josh@joshandmonique.com>
+Martin Weber Nissle <webernissle@gmail.com>

--- a/java/sage/WarlockRipper.java
+++ b/java/sage/WarlockRipper.java
@@ -245,7 +245,7 @@ public class WarlockRipper extends EPGDataSource
   }
 
   // This may take some time due to the diskspace calculation so do it before we connect to the server
-  public static String getSubmitInfo(Wizard wiz, String providerID)
+  private static String getSubmitInfo(Wizard wiz, String providerID)
   {
     StringBuffer sb = new StringBuffer();
     sb.append("SUBMIT_INFO ");
@@ -311,7 +311,11 @@ public class WarlockRipper extends EPGDataSource
   protected boolean extractGuide(long inGuideTime)
   {
     if (!doesHaveEpgLicense()) {
-      System.out.println("You do not have a SageTV license, you cannot download EPG data.");
+      if (usesPlugin())
+      {
+        return EPG.getInstance().pluginExtractGuide(Long.toString(providerID));
+      }
+      System.out.println("You do not have a SageTV license or an EPG plugin installed, you cannot download EPG data.");
       return false;
     }
     guideTime = Sage.time(); //inGuideTime;

--- a/native/ax/Channel-2/Channel.c
+++ b/native/ax/Channel-2/Channel.c
@@ -49,10 +49,34 @@
 
 //*********************** WINDOWS section *********************
 #else
-#ifdef MAC
+#ifdef __APPLE__
 //*********************** MAC section *************************
+#include <sys/ioctl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <sys/errno.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
+#include <getopt.h>
+#include <errno.h>
+#include <sys/time.h>
+#include <math.h>
+#include <time.h>
+#include <sys/timeb.h>
+#include <sys/types.h>
+#include <sys/un.h>
+#include <stdarg.h>
 
 #include <errno.h>
+
+// Apple OS/X has no features.h
+// Apple OS/X has no linux/dvb/frontend.h
+// Apple OS/X handles types via machine/types.h
+#include <machine/types.h>
 
 //*********************** MAC section *************************
 #else

--- a/native/ax/Channel-2/ChannelDataMng.c
+++ b/native/ax/Channel-2/ChannelDataMng.c
@@ -44,9 +44,33 @@
 
 //*********************** WINDOWS section *********************
 #else
-#ifdef MAC
+#ifdef __APPLE__
 //*********************** MAC section *************************
+#include <sys/ioctl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <sys/errno.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
+#include <getopt.h>
+#include <errno.h>
+#include <sys/time.h>
+#include <math.h>
+#include <time.h>
+#include <sys/timeb.h>
+#include <sys/types.h>
+#include <sys/un.h>
+#include <stdarg.h>
+int TranslateJWideString2( char* buf_out, int buf_out_size, unsigned short* buf_in );
+int TranslateJWideString( char* buf_out, int buf_out_size, unsigned short* buf_in );
 
+// Apple OS/X has no features.h
+// Apple OS/X handles types via machine/types.h
+#include <machine/types.h>
 #include <libkern/OSByteOrder.h>
 
 //*********************** MAC section *************************

--- a/native/ax/Channel-2/Makefile
+++ b/native/ax/Channel-2/Makefile
@@ -1,6 +1,22 @@
-##Created by Qian Zhang, 09/27/09.
-##
-#makefile for linux
+# Copyright 2015 The SageTV Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# native/ax/Channel-2 Makefile - builds a shared library
+# Created by Qian Zhang, 09/27/09. makefile for linux
+
+# set system name (will be Linux or Darwin)
+UNAME_S := $(shell uname -s)
 
 #Select debug you want
 DEBUG=-DDEBUG_LINUX
@@ -10,6 +26,11 @@ JAVA_HOME ?= /opt/jdk1.5.0_02
 
 #CC=gcc
 BINDIR=/usr/local/bin
+
+#TODO review debug handling overall and in particular
+ifeq ($(UNAME_S),Darwin)
+DEBUG=-DDEBUG_DARWIN -O0
+endif
 
 ifdef TARGET
 	CROSS_PREFIX:=$(TARGET)-
@@ -22,8 +43,9 @@ AR:=$(CROSS_PREFIX)ar
 RANLIB:=$(CROSS_PREFIX)ranlib
 STRIP:=$(CROSS_PREFIX)strip
 
+# changed to JDK_HOME
 #JSDK=-I/usr/local/j2sdk/include/ -I/usr/local/j2sdk/include/linux
-JSDK=-I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/linux
+JSDK=-I$(JDK_HOME)/include -I$(JDK_HOME)/include/linux
 INCLUDE= -I../Native2.0/NativeCore
 
 CFLAGS=-fPIC -D_FILE_OFFSET_BITS=64 -Wall -Wno-missing-braces -DLinux $(INCLUDE) $(JSDK) $(DEBUG)

--- a/native/ax/Native2.0/NativeCore/AVFormat/MpegVideoFormat.h
+++ b/native/ax/Native2.0/NativeCore/AVFormat/MpegVideoFormat.h
@@ -52,7 +52,7 @@ inline static const unsigned char* SearchMPEGStartCode( const unsigned char* pDa
 	unsigned long code;
 
 	if ( nBytes < 4 )
-		return NULL;
+		return (unsigned char *)NULL;
 
 	code = 0xffffff00 |*pData++;
 	while ( --nBytes )
@@ -62,7 +62,7 @@ inline static const unsigned char* SearchMPEGStartCode( const unsigned char* pDa
 		code = (( code << 8 )| *pData++ );
 	}
 
-	return NULL;
+	return (unsigned char *)NULL;
 }
 
 

--- a/native/ax/Native2.0/NativeCore/Makefile
+++ b/native/ax/Native2.0/NativeCore/Makefile
@@ -1,10 +1,30 @@
-##Original Qian Zhang, 6/1/09.
-#makefile for linux
+# Copyright 2015 The SageTV Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# native/ax/Native2.0/NativeCore Makefile - builds a shared library
+# Original Qian Zhang, 6/1/09. makefile for linux
+
+# set system name (will be Linux or Darwin)
+UNAME_S := $(shell uname -s)
 
 #Select debug you want
 DEBUG=-DDEBUG_LINUX
 CPU_TUNE=
 OS=-DLinux
+ifeq ($(UNAME_S),Darwin)
+OS=-DDarwin
+endif
 
 #CC=gcc
 #CC=mipsel-unknown-linux-gnu-gcc
@@ -23,6 +43,7 @@ AR:=$(CROSS_PREFIX)ar
 RANLIB:=$(CROSS_PREFIX)ranlib
 STRIP:=$(CROSS_PREFIX)strip
 
+#TODO why do we need here JAVA_HOME? Don't see usage and if it should be JDK_HOME
 # allow the jdk to reside elsewhere, just export JAVA_HOME
 JAVA_HOME ?= /opt/jdk1.5.0_02
 #JSDK=-I/usr/local/j2sdk/include/ -I/usr/local/j2sdk/include/linux
@@ -58,7 +79,11 @@ $(TARGETDIR):
 	touch $(TARGETDIR)
 
 $(TARGETDIR)/libNativeCore.so: $(TARGETDIR) $(OBJS)
+ifeq ($(UNAME_S),Darwin)
+	$(CC) -shared -o $(TARGETDIR)/libNativeCore.so $(OBJS) $(CPU_TUNE)
+else
 	$(CC) -shared -Wl,-Map=libNativeCore.map -o $(TARGETDIR)/libNativeCore.so $(OBJS) $(CPU_TUNE)
+endif
 
 $(TARGETDIR)/libNativeCored.so: $(TARGETDIR) $(OBJS)
 	$(CC) -shared -o $(TARGETDIR)/libNativeCored.so $(OBJS) $(CPU_TUNE)

--- a/native/ax/Native2.0/NativeCore/NativeCore.h
+++ b/native/ax/Native2.0/NativeCore/NativeCore.h
@@ -31,6 +31,7 @@ extern "C" {
 
 #define _USE_32BIT_TIME_T
 
+// TODO why this check, above is already a WIN32 check?
 #ifdef WIN32
 typedef			 _int64  LONGLONG;
 typedef unsigned _int64  ULONGLONG;
@@ -43,6 +44,7 @@ typedef LONGLONG REFERENCE_TIME;
 #define inline __inline__
 #endif
 
+// TODO why linux here within WIN32 - is about MINGW / Cygwin support?
 #ifdef Linux
 #define _MAX_PATH       512
 #endif
@@ -73,8 +75,8 @@ typedef LONGLONG REFERENCE_TIME;
 #define FCLOSE	close
 #define FSEEK	_lseeki64
 #define FTELL	_telli64
-
 #endif
+
 #ifdef Linux   //
 
 #include <stdio.h>
@@ -114,6 +116,49 @@ typedef ULONGLONG REFERENCE_TIME;
 #define ASSERT   assert
 #endif
 
+// added define for Apple OS/X, added OSByteOrder in comparison to Linux
+#ifdef __APPLE__
+#include <stdio.h>
+#include <sys/ioctl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <unistd.h>
+#include <memory.h>
+#include <stdlib.h>
+#include <libkern/OSByteOrder.h>
+
+#define lseek64 lseek
+#define open64 open
+
+#define TEXT( x )	x
+#define snprintf snprintf
+#define vnprintf vnprintf
+#define lstrlen	strlen
+#define lstrcat	strcat
+
+#define STRNICMP   strncasecmp
+#define STRICMP    strcasecmp
+
+//#define FOPEN	open64
+#define FCLOSE	close
+#define FSEEK	lseek64
+#define FTELL(x)	lseek64(x, 0, SEEK_END)
+
+#ifndef __USE_FILE_OFFSET64
+typedef long long off64_t;
+extern off64_t lseek64( int filedes, off64_t offset, int whence );
+extern off64_t tell64( int filedes );
+#endif
+
+typedef			 long long  LONGLONG;
+typedef unsigned long long ULONGLONG;
+typedef ULONGLONG REFERENCE_TIME;
+#define ASSERT   assert
+
+#endif
 
 #define _MIN(x,y) ((x)>(y)? (y):(x))
 #define _MAX(x,y) ((x)>(y)? (x):(y))

--- a/native/ax/Native2.0/NativeCore/PSIParser.c
+++ b/native/ax/Native2.0/NativeCore/PSIParser.c
@@ -436,11 +436,13 @@ int TransJWideString( char* pBufOut, int nBufOutSize, unsigned short* pBufIn )
 	while ( *p && len + MB_CUR_MAX < nBufOutSize ) 
 	{
 		unsigned short wch;
+
+		// TODO validate the APPLE and BIGENDIAN behavior, instead of "len" it was using "i" but "i" was not defined anymore, so assume it would be "len"
 #if defined(__APPLE__)
-		wch = (wchar_t)OSReadBigInt16(p, i * 2);
+		wch = (wchar_t)OSReadBigInt16(p, len * 2);
 #else
 #if defined( BIGENDIAN )
-		wch = p[i];
+		wch = p[len];
 #else
 		wch =  ( ((*p<<8)&0xff00) | *p >> 8 ); 
 #endif

--- a/native/so/HDHomeRun2.0/DTVChannel.cp
+++ b/native/so/HDHomeRun2.0/DTVChannel.cp
@@ -491,14 +491,16 @@ int DTVChannel::setTuning(SageTuningParams *params)
 			bool isDVBT = (strcmp("DVB-T", mTuningParams.tunerMode)==0);
 			bool isDVBC = (strcmp("DVB-C", mTuningParams.tunerMode)==0);
 			bool isDVBS = (strcmp("DVB-S", mTuningParams.tunerMode)==0);
+			bool isDVBTC = (strcmp("DVB-TC", mTuningParams.tunerMode)==0);
 
-
+			// TODO make tunerType dependent on isCable for HD HomeRun 3 DUAL EU edition (dvbtc)
 			if ( !isATSC && !isDVBT && !isDVBC && !isDVBS && tunerType != NULL )
 			{
 				if ( !(isATSC = (strcmp("ATSC",  tunerType)==0)) )
 					if (!( isDVBT = (strcmp("DVB-T", tunerType)==0) ))
-						if ( !(isDVBC = (strcmp("DVB-C", tunerType)==0) ) )
-							isDVBS = (strcmp("DVB-S", tunerType)==0);
+						if (!( isDVBTC = (strcmp("DVB-TC", tunerType)==0) ))
+							if ( !(isDVBC = (strcmp("DVB-C", tunerType)==0) ) )
+								isDVBS = (strcmp("DVB-S", tunerType)==0);
 			}
 			
 			setTunerMode(&mChannel, mTuningParams.tunerMode);
@@ -524,6 +526,19 @@ int DTVChannel::setTuning(SageTuningParams *params)
 			{
 				setFreqType(&mChannel, 1);
 				setSourceType(&mChannel, "DVB-C");
+			} else
+			if( isDVBTC )
+			{
+				// special tuner type handling for HDHR3-EU HDHomeRun DUAL which has DVB-T and DVB-C
+				// use the cable or OTA setting to determine what to use
+				// the HDHR3-US version with ATSC and QAM is already properly handled below
+				setFreqType(&mChannel, 1);
+				if ( isCable ) {
+					setSourceType(&mChannel, "DVB-C");
+				}
+				else {
+					setSourceType(&mChannel, "DVB-T");
+				}
 			} else
 			if( isDVBS )
 			{

--- a/native/so/HDHomeRun2.0/HDHRDevice.cp
+++ b/native/so/HDHomeRun2.0/HDHRDevice.cp
@@ -475,9 +475,11 @@ void HDHRDevice::stopCapture()
 	mLastMealSize = 0;
 }
 
+// Identifies the tuner type
 const char* HDHRDevice::getTunerType( )
 {
 	if ( strstr( mDeviceModel, "atsc" ) ) return "ATSC";
+	if ( strstr( mDeviceModel, "dvbtc" ) ) return "DVB-TC"; // HD HomeRun 3 DUAL EU edition, can be either DVB-C or DVB-T
 	if ( strstr( mDeviceModel, "dvbt" ) ) return "DVB-T";
 	if ( strstr( mDeviceModel, "dvbc" ) ) return "DVB-C";
 	if ( strstr( mDeviceModel, "dvbs" ) ) return "DVB-S";

--- a/native/so/HDHomeRun2.0/Makefile
+++ b/native/so/HDHomeRun2.0/Makefile
@@ -1,4 +1,21 @@
+# Copyright 2015 The SageTV Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# native/so/HDHomeRun2.0 Makefile - builds a shared library - interface of libhdhomerun to Java part of SageTV
 
+# set system name (will be Linux or Darwin)
+UNAME_S := $(shell uname -s)
 
 #TSNATIVE_LIB=../../lib/TSnative/libTSnative.so
 #TSNATIVED_LIB=../../lib/TSnative/libTSnatived.so
@@ -59,11 +76,17 @@ STRIP:=$(CROSS_PREFIX)strip
 CFLAGS = -fPIC -Wall -Wno-unknown-pragmas -Wno-write-strings $(NATIVECORE_INC) $(CHANNEL_INC) $(DEBUG_OPTION) -I$(HDHR_DIR) -I../../include -Istage/include -Istage/include/hdhomerun -c -fPIC -I$(JDK_HOME)/include/ -I$(JDK_HOME)/include/linux -DSAGE_DTV_ONLY=1 -D_FILE_OFFSET_BITS=64 -DLinux
 LDFLAGS =-Lstage/lib -L.
 BINDIR=/usr/local/bin
+# Apple OS/X overwrite CFLAGS and LDFLAGS which are only working on Linux
+ifeq ($(UNAME_S),Darwin)
+CFLAGS = -fPIC -Wall -Wno-unknown-pragmas -Wno-write-strings $(NATIVECORE_INC) $(CHANNEL_INC) $(DEBUG_OPTION) -I$(HDHR_DIR) -I../../include -Istage/include -Istage/include/hdhomerun -c -fPIC -I$(JDK_HOME)/include/ -I$(JDK_HOME)/include/darwin -DSAGE_DTV_ONLY=1 -D_FILE_OFFSET_BITS=64 -DDarwin
+LDFLAGS =-Lstage/lib -L. -L$(JDK_HOME)/lib -framework JavaVM
+endif
 
 STAGE_DIR=$(abspath ./stage)
 
 LIBS = -lhdhomerun $(HDHR_LIBS) -lstdc++ -lNativeCore -lchannel
 
+#TODO verfiy this setting of optimzed versus debug
 #NOTE: not optiomized until stable
 #OPT_FLAGS = -O3
 OPT_FLAGS = -g -O0

--- a/native/so/HDHomeRun2.0/sage_HDHomeRun.cp
+++ b/native/so/HDHomeRun2.0/sage_HDHomeRun.cp
@@ -244,7 +244,9 @@ static void DiscoverNewDevices(JNIEnv *env)
 			// we won't handle upgrades in this app, they'll need to do that externally
 			struct hdhomerun_device_t *hd = hdhomerun_device_create(list[ii].device_id, list[ii].ip_addr, 0, NULL);
 			if(hd) {
-				int result = hdhomerun_device_firmware_version_check(hd, 0);
+				// update due to libhdhomerun 20150614 upgrade - changed to get_version
+				uint32_t versionint;
+				int result = hdhomerun_device_get_version(hd, NULL, &versionint);
 				if(result < 0) {
 					sysOutPrint(env, "HDHomeRun: Error checking device firmware version (%08lx, %d)\n", list[ii].device_id, result);
 					hdhomerun_device_destroy(hd);

--- a/native/so/HDHomeRun2.0/sage_HDHomeRun.cp
+++ b/native/so/HDHomeRun2.0/sage_HDHomeRun.cp
@@ -199,9 +199,8 @@ static inline HDHRDevice *findDeviceByName(char *name)
 
 static void DiscoverNewDevices(JNIEnv *env)
 {
-	int count, ii, jj;
+	int count, ii, jj, kk;
 	struct hdhomerun_discover_device_t list[kHDHRDeviceListSize];
-
 
 	if ( _flog_local_check() )
 	{
@@ -257,22 +256,23 @@ static void DiscoverNewDevices(JNIEnv *env)
 					hdhomerun_device_destroy(hd);
 					continue;
 				}
+				DebugLog(env, "New HDHomeRun device discovered with firmware version &d\n", versionint);
 				hdhomerun_device_destroy(hd);
 			} else {
 				sysOutPrint(env, "HDHomeRun: Error connecting to device %08lx\n", list[ii].device_id);
 				continue;
 			}
 			
-			DebugLog(env, "New HDHomeRun device discovered (id = %08lx, ip = %08lx)\n", list[ii].device_id, list[ii].ip_addr);
+			DebugLog(env, "New HDHomeRun device discovered (id = %08lx, ip = %08lx, tuners = %d)\n", list[ii].device_id, list[ii].ip_addr, list[ii].tuner_count);
 			memcpy(&gDeviceList[gDeviceListCount], &list[ii], sizeof(struct hdhomerun_discover_device_t));
 			gDeviceListCount++;
-			
-			// and create input entries for the device
-				// TODO: get actual number and types of tuners, types needed for DVB-T support
+
+			// get actual number of tuners and create entries - was hardcoded to two tuners previously
 			pthread_mutex_lock(&gInputListLock);
-			gInputList->push_back(new HDHRDevice(list[ii], 0));
-			gInputList->push_back(new HDHRDevice(list[ii], 1));
-			gInputListCount += 2;
+			for (kk=0; kk<list[ii].tuner_count; kk++) {
+				gInputList->push_back(new HDHRDevice(list[ii], kk));
+				gInputListCount += 1;
+			}
 			pthread_mutex_unlock(&gInputListLock);
 		}
 	}

--- a/native/so/SageLinux/Makefile
+++ b/native/so/SageLinux/Makefile
@@ -1,3 +1,22 @@
+# Copyright 2015 The SageTV Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# native/so/SageLinux Makefile - builds a shared library
+
+# set system name (will be Linux or Darwin)
+UNAME_S := $(shell uname -s)
+
 JDK_HOME ?= /usr/local/j2sdk
 #JAVA_ARCH ?= i386
 JAVA_ARCH ?= amd64
@@ -6,12 +25,19 @@ JAVA_ARCH ?= amd64
 CC=gcc
 #CC=mipsel-unknown-linux-gnu-gcc
 CFLAGS = -c -fPIC -I$(JDK_HOME)/include -I$(JDK_HOME)/include/linux -D_FILE_OFFSET_BITS=64
+ifeq ($(UNAME_S),Darwin)
+CFLAGS = -c -fPIC -I$(JDK_HOME)/include -I$(JDK_HOME)/include/darwin -D_FILE_OFFSET_BITS=64
+endif
 BINDIR=/usr/local/bin
 
 OBJFILES=sage_Sage.o sage_MMC.o sage_VideoFrame.o sage_BasicVideoFrame.o
 
+# Apple OS/X build only non X11 library for now
+ifeq ($(UNAME_S),Darwin)
+all: libSage.so
+else
 all: libSageX11.so libSage.so
-#all: libSage.so
+endif
 
 libSageX11.so: $(OBJFILES) sage_UIManagerX11.o
 	$(CC) -shared -o libSageX11.so  $(OBJFILES) sage_UIManagerX11.o -L$(JDK_HOME)/jre/lib/$(JAVA_ARCH) -ldl -lX11 -ljawt 

--- a/native/so/SageLinux/sage_Sage.c
+++ b/native/so/SageLinux/sage_Sage.c
@@ -16,9 +16,16 @@
 #include <jni.h>
 #include <stdio.h>
 #include "sage_Sage.h"
+#ifdef __APPLE__
+#include <sys/param.h>
+#include <sys/mount.h>
+#include <machine/types.h>
+#else
 #include <sys/vfs.h>
-#include <sys/time.h>
 #include <linux/types.h>
+#endif
+
+#include <sys/time.h>
 #include <time.h>
 #include <sys/timeb.h>
 #include <sys/types.h>
@@ -260,8 +267,11 @@ JNIEXPORT jint JNICALL Java_sage_Sage_getFileSystemIdentifier(JNIEnv *env, jclas
   
   (*env)->ReleaseStringUTFChars(env, volRoot, str);
 
+#ifdef __APPLE__
+  return (fs.f_fsid.val[0]);
+#else
   return (fs.f_fsid.__val[0]);
-
+#endif
 }
 
 // ***************************************************************************

--- a/third_party/SiliconDust/libhdhomerun/Makefile
+++ b/third_party/SiliconDust/libhdhomerun/Makefile
@@ -1,12 +1,15 @@
-LIBSRCS += hdhomerun_pkt.c
-LIBSRCS += hdhomerun_debug.c
-LIBSRCS += hdhomerun_discover.c
+
 LIBSRCS += hdhomerun_channels.c
 LIBSRCS += hdhomerun_channelscan.c
 LIBSRCS += hdhomerun_control.c
-LIBSRCS += hdhomerun_video.c
+LIBSRCS += hdhomerun_debug.c
 LIBSRCS += hdhomerun_device.c
 LIBSRCS += hdhomerun_device_selector.c
+LIBSRCS += hdhomerun_discover.c
+LIBSRCS += hdhomerun_os_posix.c
+LIBSRCS += hdhomerun_pkt.c
+LIBSRCS += hdhomerun_sock_posix.c
+LIBSRCS += hdhomerun_video.c
 
 CC    := $(CROSS_COMPILE)gcc
 STRIP := $(CROSS_COMPILE)strip
@@ -20,12 +23,16 @@ ifeq ($(OS),Windows_NT)
   LIBEXT := .dll
   LDFLAGS += -liphlpapi
 else
+  OS := $(shell uname -s)
   LIBEXT := .so
-  ifneq ($(findstring solaris,$(shell echo $$OSTYPE)),)
-    LDFLAGS += -lns -lsocket
+  ifeq ($(OS),Linux)
+    LDFLAGS += -lrt
   endif
-  ifneq ($(findstring darwin,$(shell echo $$OSTYPE)),)
-    CFLAGS += -arch i386 -arch ppc
+  ifeq ($(OS),SunOS)
+    LDFLAGS += -lsocket
+  endif
+  ifeq ($(OS),Darwin)
+    CFLAGS += -arch i386 -arch x86_64
     LIBEXT := .dylib
     SHARED := -dynamiclib -install_name libhdhomerun$(LIBEXT)
   endif

--- a/third_party/SiliconDust/libhdhomerun/README
+++ b/third_party/SiliconDust/libhdhomerun/README
@@ -3,10 +3,10 @@
  *
  * Copyright © 2005-2009 Silicondust USA Inc. <www.silicondust.com>.
  *
- * This library is free software; you can redistribute it and/or 
+ * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
+ * version 2.1 of the License, or (at your option) any later version.
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -14,20 +14,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
- * 
- * As a special exception to the GNU Lesser General Public License,
- * you may link, statically or dynamically, an application with a
- * publicly distributed version of the Library to produce an
- * executable file containing portions of the Library, and
- * distribute that executable file under terms of your choice,
- * without any of the additional requirements listed in clause 4 of
- * the GNU Lesser General Public License.
- * 
- * By "a publicly distributed version of the Library", we mean
- * either the unmodified Library as distributed by Silicondust, or a
- * modified version of the Library that is distributed under the
- * conditions defined in the GNU Lesser General Public License.
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
 Top level include file: hdhomerun.h

--- a/third_party/SiliconDust/libhdhomerun/hdhomerun.h
+++ b/third_party/SiliconDust/libhdhomerun/hdhomerun.h
@@ -1,12 +1,12 @@
 /*
  * hdhomerun.h
  *
- * Copyright © 2006-2008 Silicondust USA Inc. <www.silicondust.com>.
+ * Copyright © 2006-2010 Silicondust USA Inc. <www.silicondust.com>.
  *
- * This library is free software; you can redistribute it and/or 
+ * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
+ * version 2.1 of the License, or (at your option) any later version.
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -14,25 +14,14 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
- * 
- * As a special exception to the GNU Lesser General Public License,
- * you may link, statically or dynamically, an application with a
- * publicly distributed version of the Library to produce an
- * executable file containing portions of the Library, and
- * distribute that executable file under terms of your choice,
- * without any of the additional requirements listed in clause 4 of
- * the GNU Lesser General Public License.
- * 
- * By "a publicly distributed version of the Library", we mean
- * either the unmodified Library as distributed by Silicondust, or a
- * modified version of the Library that is distributed under the
- * conditions defined in the GNU Lesser General Public License.
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
 #include "hdhomerun_os.h"
 #include "hdhomerun_types.h"
 #include "hdhomerun_pkt.h"
+#include "hdhomerun_sock.h"
 #include "hdhomerun_debug.h"
 #include "hdhomerun_discover.h"
 #include "hdhomerun_control.h"

--- a/third_party/SiliconDust/libhdhomerun/hdhomerun_channels.c
+++ b/third_party/SiliconDust/libhdhomerun/hdhomerun_channels.c
@@ -3,10 +3,10 @@
  *
  * Copyright © 2007-2008 Silicondust USA Inc. <www.silicondust.com>.
  *
- * This library is free software; you can redistribute it and/or 
+ * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
+ * version 2.1 of the License, or (at your option) any later version.
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -14,31 +14,17 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
- * 
- * As a special exception to the GNU Lesser General Public License,
- * you may link, statically or dynamically, an application with a
- * publicly distributed version of the Library to produce an
- * executable file containing portions of the Library, and
- * distribute that executable file under terms of your choice,
- * without any of the additional requirements listed in clause 4 of
- * the GNU Lesser General Public License.
- * 
- * By "a publicly distributed version of the Library", we mean
- * either the unmodified Library as distributed by Silicondust, or a
- * modified version of the Library that is distributed under the
- * conditions defined in the GNU Lesser General Public License.
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
 #include "hdhomerun.h"
-
-#define FREQUENCY_RESOLUTION 62500
 
 struct hdhomerun_channel_entry_t {
 	struct hdhomerun_channel_entry_t *next;
 	struct hdhomerun_channel_entry_t *prev;
 	uint32_t frequency;
-	uint8_t channel_number;
+	uint16_t channel_number;
 	char name[16];
 };
 
@@ -48,47 +34,53 @@ struct hdhomerun_channel_list_t {
 };
 
 struct hdhomerun_channelmap_range_t {
-	uint8_t channel_range_start;
-	uint8_t channel_range_end;
+	uint16_t channel_range_start;
+	uint16_t channel_range_end;
 	uint32_t frequency;
 	uint32_t spacing;
 };
 
 struct hdhomerun_channelmap_record_t {
-	const char *channelmap_prefix;
 	const char *channelmap;
 	const struct hdhomerun_channelmap_range_t *range_list;
 	const char *channelmap_scan_group;
 	const char *countrycodes;
 };
 
-/* AU antenna channels. Channels {0, 1, 2, 6, 7, 8, 9, 9A} are numbered {2, 3, 4, 5, 6, 7, 8, 9} by the HDHomeRun. */
+/* AU antenna channels. Channels {6, 7, 8, 9, 9A} are numbered {5, 6, 7, 8, 9} by the HDHomeRun. */
 static const struct hdhomerun_channelmap_range_t hdhomerun_channelmap_range_au_bcast[] = {
-	{  2,   2,  48500000, 7000000},
-	{  3,   4,  59500000, 7000000},
 	{  5,  12, 177500000, 7000000},
-	{ 28,  69, 529500000, 7000000},
-	{  0,   0,         0,       0}
-};
-
-/* AU cable channels. TBD. */
-static const struct hdhomerun_channelmap_range_t hdhomerun_channelmap_range_au_cable[] = {
+	{ 21,  69, 480500000, 7000000},
 	{  0,   0,         0,       0}
 };
 
 /* EU antenna channels. */
 static const struct hdhomerun_channelmap_range_t hdhomerun_channelmap_range_eu_bcast[] = {
-	{  2,   4,  50500000, 7000000},
 	{  5,  12, 177500000, 7000000},
 	{ 21,  69, 474000000, 8000000},
 	{  0,   0,         0,       0}
 };
 
-/* EU cable channels. Channels do not have simple numbers - the HDHomeRun uses its own numbering scheme (subject to change). */
+/* EU cable channels. No common standard - use frequency in MHz for channel number. */
 static const struct hdhomerun_channelmap_range_t hdhomerun_channelmap_range_eu_cable[] = {
-	{  6,   7, 113000000, 8000000},
-	{  9, 100, 138000000, 8000000},
+	{108, 862, 108000000, 1000000},
 	{  0,   0,         0,       0}
+};
+
+/* KR cable channels. */
+static const struct hdhomerun_channelmap_range_t hdhomerun_channelmap_range_kr_cable[] = {
+	{  2,   4,  57000000, 6000000},
+	{  5,   6,  79000000, 6000000},
+	{  7,  13, 177000000, 6000000},
+	{ 14,  22, 123000000, 6000000},
+	{ 23, 153, 219000000, 6000000},
+	{  0,   0,         0,       0}
+};
+
+/* JP antenna channels. */
+static const struct hdhomerun_channelmap_range_t hdhomerun_channelmap_range_jp_bcast[] = {
+	{ 13, 62, 473000000, 6000000},
+	{  0,  0,         0,       0}
 };
 
 /* US antenna channels. */
@@ -108,7 +100,7 @@ static const struct hdhomerun_channelmap_range_t hdhomerun_channelmap_range_us_c
 	{ 14,  22, 123000000, 6000000},
 	{ 23,  94, 219000000, 6000000},
 	{ 95,  99,  93000000, 6000000},
-	{100, 135, 651000000, 6000000},
+	{100, 158, 651000000, 6000000},
 	{  0,   0,         0,       0}
 };
 
@@ -120,7 +112,7 @@ static const struct hdhomerun_channelmap_range_t hdhomerun_channelmap_range_us_h
 	{ 14,  22, 121756000, 6000300},
 	{ 23,  94, 217760800, 6000300},
 	{ 95,  99,  91754500, 6000300},
-	{100, 135, 649782400, 6000300},
+	{100, 158, 649782400, 6000300},
 	{  0,   0,         0,       0}
 };
 
@@ -135,35 +127,65 @@ static const struct hdhomerun_channelmap_range_t hdhomerun_channelmap_range_us_i
 	{ 43,  94, 339012500, 6000000},
 	{ 95,  97,  93012500, 6000000},
 	{ 98,  99, 111025000, 6000000},
-	{100, 135, 651012500, 6000000},
+	{100, 158, 651012500, 6000000},
 	{  0,   0,         0,       0}
 };
 
 static const struct hdhomerun_channelmap_record_t hdhomerun_channelmap_table[] = {
-	{"au", "au-bcast", hdhomerun_channelmap_range_au_bcast, "au-bcast",               "AU"},
-	{"au", "au-cable", hdhomerun_channelmap_range_au_cable, "au-cable",               "AU"},
-	{"eu", "eu-bcast", hdhomerun_channelmap_range_eu_bcast, "eu-bcast",               "EU"},
-	{"eu", "eu-cable", hdhomerun_channelmap_range_eu_cable, "eu-cable",               "EU"},
-	{"tw", "tw-bcast", hdhomerun_channelmap_range_us_bcast, "tw-bcast",               "TW"},
-	{"tw", "tw-cable", hdhomerun_channelmap_range_us_cable, "tw-cable",               "TW"},
-	{"us", "us-bcast", hdhomerun_channelmap_range_us_bcast, "us-bcast",               "CA US"},
-	{"us", "us-cable", hdhomerun_channelmap_range_us_cable, "us-cable us-hrc us-irc", "CA US"},
-	{"us", "us-hrc",   hdhomerun_channelmap_range_us_hrc  , "us-cable us-hrc us-irc", "CA US"},
-	{"us", "us-irc",   hdhomerun_channelmap_range_us_irc,   "us-cable us-hrc us-irc", "CA US"},
-	{NULL, NULL,       NULL,                                NULL,                     NULL}
+	{"au-bcast", hdhomerun_channelmap_range_au_bcast, "au-bcast",               "AU"},
+	{"au-cable", hdhomerun_channelmap_range_eu_cable, "au-cable",               "AU"},
+	{"eu-bcast", hdhomerun_channelmap_range_eu_bcast, "eu-bcast",               NULL},
+	{"eu-cable", hdhomerun_channelmap_range_eu_cable, "eu-cable",               NULL},
+	{"tw-bcast", hdhomerun_channelmap_range_us_bcast, "tw-bcast",               "TW"},
+	{"tw-cable", hdhomerun_channelmap_range_us_cable, "tw-cable",               "TW"},
+
+	{"kr-bcast", hdhomerun_channelmap_range_us_bcast, "kr-bcast",               "KR"},
+	{"kr-cable", hdhomerun_channelmap_range_kr_cable, "kr-cable",               "KR"},
+	{"us-bcast", hdhomerun_channelmap_range_us_bcast, "us-bcast",               NULL},
+	{"us-cable", hdhomerun_channelmap_range_us_cable, "us-cable us-hrc us-irc", NULL},
+	{"us-hrc",   hdhomerun_channelmap_range_us_hrc  , "us-cable us-hrc us-irc", NULL},
+	{"us-irc",   hdhomerun_channelmap_range_us_irc,   "us-cable us-hrc us-irc", NULL},
+
+	{"jp-bcast", hdhomerun_channelmap_range_jp_bcast, "jp-bcast",               "JP" },
+	{ NULL, NULL, NULL, NULL }
 };
 
-const char *hdhomerun_channelmap_convert_countrycode_to_channelmap_prefix(const char *countrycode)
+const char *hdhomerun_channelmap_get_channelmap_from_country_source(const char *countrycode, const char *source, const char *supported)
 {
+	const char *default_result = NULL;
+
 	const struct hdhomerun_channelmap_record_t *record = hdhomerun_channelmap_table;
 	while (record->channelmap) {
-		if (strstr(record->countrycodes, countrycode)) {
-			return record->channelmap_prefix;
+		/* Ignore records that do not match the requested source. */
+		if (!strstr(record->channelmap, source)) {
+			record++;
+			continue;
 		}
-		record++;
+
+		/* Ignore records that are not supported by the hardware. */
+		if (!strstr(supported, record->channelmap)) {
+			record++;
+			continue;
+		}
+
+		/* If this record is the default result then remember it and keep searching. */
+		if (!record->countrycodes) {
+			default_result = record->channelmap;
+			record++;
+			continue;
+		}
+
+		/* Ignore records that have a countrycode filter and do not match. */
+		if (!strstr(record->countrycodes, countrycode)) {
+			record++;
+			continue;
+		}
+
+		/* Record found with exact match for source and countrycode. */
+		return record->channelmap;
 	}
 
-	return "eu";
+	return default_result;
 }
 
 const char *hdhomerun_channelmap_get_channelmap_scan_group(const char *channelmap)
@@ -179,7 +201,7 @@ const char *hdhomerun_channelmap_get_channelmap_scan_group(const char *channelma
 	return NULL;
 }
 
-uint8_t hdhomerun_channel_entry_channel_number(struct hdhomerun_channel_entry_t *entry)
+uint16_t hdhomerun_channel_entry_channel_number(struct hdhomerun_channel_entry_t *entry)
 {
 	return entry->channel_number;
 }
@@ -245,12 +267,18 @@ uint32_t hdhomerun_channel_list_frequency_count(struct hdhomerun_channel_list_t 
 	return count;
 }
 
-uint32_t hdhomerun_channel_frequency_truncate(uint32_t frequency)
+uint32_t hdhomerun_channel_frequency_round(uint32_t frequency, uint32_t resolution)
 {
-	return (frequency / FREQUENCY_RESOLUTION) * FREQUENCY_RESOLUTION;
+	frequency += resolution / 2;
+	return (frequency / resolution) * resolution;
 }
 
-uint32_t hdhomerun_channel_number_to_frequency(struct hdhomerun_channel_list_t *channel_list, uint8_t channel_number)
+uint32_t hdhomerun_channel_frequency_round_normal(uint32_t frequency)
+{
+	return hdhomerun_channel_frequency_round(frequency, 125000);
+}
+
+uint32_t hdhomerun_channel_number_to_frequency(struct hdhomerun_channel_list_t *channel_list, uint16_t channel_number)
 {
 	struct hdhomerun_channel_entry_t *entry = hdhomerun_channel_list_first(channel_list);
 	while (entry) {
@@ -264,9 +292,9 @@ uint32_t hdhomerun_channel_number_to_frequency(struct hdhomerun_channel_list_t *
 	return 0;
 }
 
-uint8_t hdhomerun_channel_frequency_to_number(struct hdhomerun_channel_list_t *channel_list, uint32_t frequency)
+uint16_t hdhomerun_channel_frequency_to_number(struct hdhomerun_channel_list_t *channel_list, uint32_t frequency)
 {
-	frequency = hdhomerun_channel_frequency_truncate(frequency);
+	frequency = hdhomerun_channel_frequency_round_normal(frequency);
 
 	struct hdhomerun_channel_entry_t *entry = hdhomerun_channel_list_first(channel_list);
 	while (entry) {
@@ -315,7 +343,7 @@ static void hdhomerun_channel_list_build_insert(struct hdhomerun_channel_list_t 
 
 static void hdhomerun_channel_list_build_range(struct hdhomerun_channel_list_t *channel_list, const char *channelmap, const struct hdhomerun_channelmap_range_t *range)
 {
-	uint8_t channel_number;
+	uint16_t channel_number;
 	for (channel_number = range->channel_range_start; channel_number <= range->channel_range_end; channel_number++) {
 		struct hdhomerun_channel_entry_t *entry = (struct hdhomerun_channel_entry_t *)calloc(1, sizeof(struct hdhomerun_channel_entry_t));
 		if (!entry) {
@@ -324,8 +352,8 @@ static void hdhomerun_channel_list_build_range(struct hdhomerun_channel_list_t *
 
 		entry->channel_number = channel_number;
 		entry->frequency = range->frequency + ((uint32_t)(channel_number - range->channel_range_start) * range->spacing);
-		entry->frequency = hdhomerun_channel_frequency_truncate(entry->frequency);
-		sprintf(entry->name, "%s:%u", channelmap, entry->channel_number);
+		entry->frequency = hdhomerun_channel_frequency_round_normal(entry->frequency);
+		hdhomerun_sprintf(entry->name, entry->name + sizeof(entry->name), "%s:%u", channelmap, entry->channel_number);
 
 		hdhomerun_channel_list_build_insert(channel_list, entry);
 	}

--- a/third_party/SiliconDust/libhdhomerun/hdhomerun_channels.h
+++ b/third_party/SiliconDust/libhdhomerun/hdhomerun_channels.h
@@ -3,10 +3,10 @@
  *
  * Copyright © 2007-2008 Silicondust USA Inc. <www.silicondust.com>.
  *
- * This library is free software; you can redistribute it and/or 
+ * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
+ * version 2.1 of the License, or (at your option) any later version.
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -14,20 +14,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
- * 
- * As a special exception to the GNU Lesser General Public License,
- * you may link, statically or dynamically, an application with a
- * publicly distributed version of the Library to produce an
- * executable file containing portions of the Library, and
- * distribute that executable file under terms of your choice,
- * without any of the additional requirements listed in clause 4 of
- * the GNU Lesser General Public License.
- * 
- * By "a publicly distributed version of the Library", we mean
- * either the unmodified Library as distributed by Silicondust, or a
- * modified version of the Library that is distributed under the
- * conditions defined in the GNU Lesser General Public License.
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
 #ifdef __cplusplus
@@ -37,10 +25,10 @@ extern "C" {
 struct hdhomerun_channel_entry_t;
 struct hdhomerun_channel_list_t;
 
-extern LIBTYPE const char *hdhomerun_channelmap_convert_countrycode_to_channelmap_prefix(const char *countrycode);
+extern LIBTYPE const char *hdhomerun_channelmap_get_channelmap_from_country_source(const char *countrycode, const char *source, const char *supported);
 extern LIBTYPE const char *hdhomerun_channelmap_get_channelmap_scan_group(const char *channelmap);
 
-extern LIBTYPE uint8_t hdhomerun_channel_entry_channel_number(struct hdhomerun_channel_entry_t *entry);
+extern LIBTYPE uint16_t hdhomerun_channel_entry_channel_number(struct hdhomerun_channel_entry_t *entry);
 extern LIBTYPE uint32_t hdhomerun_channel_entry_frequency(struct hdhomerun_channel_entry_t *entry);
 extern LIBTYPE const char *hdhomerun_channel_entry_name(struct hdhomerun_channel_entry_t *entry);
 
@@ -54,9 +42,10 @@ extern LIBTYPE struct hdhomerun_channel_entry_t *hdhomerun_channel_list_prev(str
 extern LIBTYPE uint32_t hdhomerun_channel_list_total_count(struct hdhomerun_channel_list_t *channel_list);
 extern LIBTYPE uint32_t hdhomerun_channel_list_frequency_count(struct hdhomerun_channel_list_t *channel_list);
 
-extern LIBTYPE uint32_t hdhomerun_channel_frequency_truncate(uint32_t frequency);
-extern LIBTYPE uint32_t hdhomerun_channel_number_to_frequency(struct hdhomerun_channel_list_t *channel_list, uint8_t channel_number);
-extern LIBTYPE uint8_t hdhomerun_channel_frequency_to_number(struct hdhomerun_channel_list_t *channel_list, uint32_t frequency);
+extern LIBTYPE uint32_t hdhomerun_channel_frequency_round(uint32_t frequency, uint32_t resolution);
+extern LIBTYPE uint32_t hdhomerun_channel_frequency_round_normal(uint32_t frequency);
+extern LIBTYPE uint32_t hdhomerun_channel_number_to_frequency(struct hdhomerun_channel_list_t *channel_list, uint16_t channel_number);
+extern LIBTYPE uint16_t hdhomerun_channel_frequency_to_number(struct hdhomerun_channel_list_t *channel_list, uint32_t frequency);
 
 #ifdef __cplusplus
 }

--- a/third_party/SiliconDust/libhdhomerun/hdhomerun_channelscan.h
+++ b/third_party/SiliconDust/libhdhomerun/hdhomerun_channelscan.h
@@ -3,10 +3,10 @@
  *
  * Copyright © 2007-2008 Silicondust USA Inc. <www.silicondust.com>.
  *
- * This library is free software; you can redistribute it and/or 
+ * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
+ * version 2.1 of the License, or (at your option) any later version.
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -14,20 +14,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
- * 
- * As a special exception to the GNU Lesser General Public License,
- * you may link, statically or dynamically, an application with a
- * publicly distributed version of the Library to produce an
- * executable file containing portions of the Library, and
- * distribute that executable file under terms of your choice,
- * without any of the additional requirements listed in clause 4 of
- * the GNU Lesser General Public License.
- * 
- * By "a publicly distributed version of the Library", we mean
- * either the unmodified Library as distributed by Silicondust, or a
- * modified version of the Library that is distributed under the
- * conditions defined in the GNU Lesser General Public License.
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
 #ifdef __cplusplus

--- a/third_party/SiliconDust/libhdhomerun/hdhomerun_control.h
+++ b/third_party/SiliconDust/libhdhomerun/hdhomerun_control.h
@@ -3,10 +3,10 @@
  *
  * Copyright © 2006 Silicondust USA Inc. <www.silicondust.com>.
  *
- * This library is free software; you can redistribute it and/or 
+ * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
+ * version 2.1 of the License, or (at your option) any later version.
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -14,20 +14,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
- * 
- * As a special exception to the GNU Lesser General Public License,
- * you may link, statically or dynamically, an application with a
- * publicly distributed version of the Library to produce an
- * executable file containing portions of the Library, and
- * distribute that executable file under terms of your choice,
- * without any of the additional requirements listed in clause 4 of
- * the GNU Lesser General Public License.
- * 
- * By "a publicly distributed version of the Library", we mean
- * either the unmodified Library as distributed by Silicondust, or a
- * modified version of the Library that is distributed under the
- * conditions defined in the GNU Lesser General Public License.
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 #ifdef __cplusplus
 extern "C" {

--- a/third_party/SiliconDust/libhdhomerun/hdhomerun_debug.c
+++ b/third_party/SiliconDust/libhdhomerun/hdhomerun_debug.c
@@ -1,12 +1,12 @@
 /*
  * hdhomerun_debug.c
  *
- * Copyright © 2006 Silicondust USA Inc. <www.silicondust.com>.
+ * Copyright © 2006-2010 Silicondust USA Inc. <www.silicondust.com>.
  *
- * This library is free software; you can redistribute it and/or 
+ * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
+ * version 2.1 of the License, or (at your option) any later version.
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -14,20 +14,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
- * 
- * As a special exception to the GNU Lesser General Public License,
- * you may link, statically or dynamically, an application with a
- * publicly distributed version of the Library to produce an
- * executable file containing portions of the Library, and
- * distribute that executable file under terms of your choice,
- * without any of the additional requirements listed in clause 4 of
- * the GNU Lesser General Public License.
- * 
- * By "a publicly distributed version of the Library", we mean
- * either the unmodified Library as distributed by Silicondust, or a
- * modified version of the Library that is distributed under the
- * conditions defined in the GNU Lesser General Public License.
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
 /*
@@ -44,8 +32,12 @@
 #define HDHOMERUN_DEBUG_HOST "debug.silicondust.com"
 #endif
 #if !defined(HDHOMERUN_DEBUG_PORT)
-#define HDHOMERUN_DEBUG_PORT "8002"
+#define HDHOMERUN_DEBUG_PORT 8002
 #endif
+
+#define HDHOMERUN_DEBUG_CONNECT_RETRY_TIME 30000
+#define HDHOMERUN_DEBUG_CONNECT_TIMEOUT 10000
+#define HDHOMERUN_DEBUG_SEND_TIMEOUT 10000
 
 struct hdhomerun_debug_message_t
 {
@@ -73,7 +65,7 @@ struct hdhomerun_debug_t
 
 	char *file_name;
 	FILE *file_fp;
-	int sock;
+	hdhomerun_sock_t sock;
 };
 
 static THREAD_FUNC_PREFIX hdhomerun_debug_thread_execute(void *arg);
@@ -85,7 +77,7 @@ struct hdhomerun_debug_t *hdhomerun_debug_create(void)
 		return NULL;
 	}
 
-	dbg->sock = -1;
+	dbg->sock = HDHOMERUN_SOCK_INVALID;
 
 	pthread_mutex_init(&dbg->print_lock, NULL);
 	pthread_mutex_init(&dbg->queue_lock, NULL);
@@ -117,8 +109,8 @@ void hdhomerun_debug_destroy(struct hdhomerun_debug_t *dbg)
 	if (dbg->file_fp) {
 		fclose(dbg->file_fp);
 	}
-	if (dbg->sock != -1) {
-		close(dbg->sock);
+	if (dbg->sock != HDHOMERUN_SOCK_INVALID) {
+		hdhomerun_sock_destroy(dbg->sock);
 	}
 
 	free(dbg);
@@ -132,9 +124,9 @@ static void hdhomerun_debug_close_internal(struct hdhomerun_debug_t *dbg)
 		dbg->file_fp = NULL;
 	}
 
-	if (dbg->sock != -1) {
-		close(dbg->sock);
-		dbg->sock = -1;
+	if (dbg->sock != HDHOMERUN_SOCK_INVALID) {
+		hdhomerun_sock_destroy(dbg->sock);
+		dbg->sock = HDHOMERUN_SOCK_INVALID;
 	}
 }
 
@@ -251,7 +243,7 @@ void hdhomerun_debug_flush(struct hdhomerun_debug_t *dbg, uint64_t timeout)
 			return;
 		}
 
-		msleep(10);
+		msleep_approx(10);
 	}
 }
 
@@ -296,12 +288,8 @@ void hdhomerun_debug_vprintf(struct hdhomerun_debug_t *dbg, const char *fmt, va_
 	pthread_mutex_lock(&dbg->print_lock);
 
 	if (dbg->prefix) {
-		int len = snprintf(ptr, end - ptr, "%s ", dbg->prefix);
-		len = (len <= 0) ? 0 : len;
-		ptr += len;
-		if (ptr > end) {
-			ptr = end;
-		}
+		hdhomerun_sprintf(ptr, end, "%s ", dbg->prefix);
+		ptr = strchr(ptr, 0);
 	}
 
 	pthread_mutex_unlock(&dbg->print_lock);
@@ -309,27 +297,15 @@ void hdhomerun_debug_vprintf(struct hdhomerun_debug_t *dbg, const char *fmt, va_
 	/*
 	 * Message text.
 	 */
-	int len = vsnprintf(ptr, end - ptr, fmt, args);
-	len = (len < 0) ? 0 : len; /* len does not include null */
-	ptr += len;
-	if (ptr > end) {
-		ptr = end;
-	}
+	hdhomerun_vsprintf(ptr, end, fmt, args);
+	ptr = strchr(ptr, 0);
 
 	/*
 	 * Force newline.
 	 */
-	if ((ptr[-1] != '\n') && (ptr + 1 <= end)) {
-		*ptr++ = '\n';
+	if (ptr[-1] != '\n') {
+		hdhomerun_sprintf(ptr, end, "\n");
 	}
-
-	/*
-	 * Force NULL.
-	 */
-	if (ptr + 1 > end) {
-		ptr = end - 1;
-	}
-	*ptr++ = 0;
 
 	/*
 	 * Enqueue.
@@ -372,54 +348,40 @@ static bool_t hdhomerun_debug_output_message_file(struct hdhomerun_debug_t *dbg,
 }
 
 /* Send lock held by caller */
-#if defined(__CYGWIN__)
 static bool_t hdhomerun_debug_output_message_sock(struct hdhomerun_debug_t *dbg, struct hdhomerun_debug_message_t *message)
 {
-	return TRUE;
-}
-#else
-static bool_t hdhomerun_debug_output_message_sock(struct hdhomerun_debug_t *dbg, struct hdhomerun_debug_message_t *message)
-{
-	if (dbg->sock == -1) {
+	if (dbg->sock == HDHOMERUN_SOCK_INVALID) {
 		uint64_t current_time = getcurrenttime();
 		if (current_time < dbg->connect_delay) {
 			return FALSE;
 		}
-		dbg->connect_delay = current_time + 30*1000;
+		dbg->connect_delay = current_time + HDHOMERUN_DEBUG_CONNECT_RETRY_TIME;
 
-		dbg->sock = (int)socket(AF_INET, SOCK_STREAM, 0);
-		if (dbg->sock == -1) {
+		dbg->sock = hdhomerun_sock_create_tcp();
+		if (dbg->sock == HDHOMERUN_SOCK_INVALID) {
 			return FALSE;
 		}
 
-		struct addrinfo hints;
-		memset(&hints, 0, sizeof(hints));
-		hints.ai_family = AF_INET;
-		hints.ai_socktype = SOCK_STREAM;
-		hints.ai_protocol = IPPROTO_TCP;
-
-		struct addrinfo *sock_info;
-		if (getaddrinfo(HDHOMERUN_DEBUG_HOST, HDHOMERUN_DEBUG_PORT, &hints, &sock_info) != 0) {
+		uint32_t remote_addr = hdhomerun_sock_getaddrinfo_addr(dbg->sock, HDHOMERUN_DEBUG_HOST);
+		if (remote_addr == 0) {
 			hdhomerun_debug_close_internal(dbg);
 			return FALSE;
 		}
-		if (connect(dbg->sock, sock_info->ai_addr, (int)sock_info->ai_addrlen) != 0) {
-			freeaddrinfo(sock_info);
+
+		if (!hdhomerun_sock_connect(dbg->sock, remote_addr, HDHOMERUN_DEBUG_PORT, HDHOMERUN_DEBUG_CONNECT_TIMEOUT)) {
 			hdhomerun_debug_close_internal(dbg);
 			return FALSE;
 		}
-		freeaddrinfo(sock_info);
 	}
 
 	size_t length = strlen(message->buffer);
-	if (send(dbg->sock, (char *)message->buffer, (int)length, 0) != length) {
+	if (!hdhomerun_sock_send(dbg->sock, message->buffer, length, HDHOMERUN_DEBUG_SEND_TIMEOUT)) {
 		hdhomerun_debug_close_internal(dbg);
 		return FALSE;
 	}
 
 	return TRUE;
 }
-#endif
 
 static bool_t hdhomerun_debug_output_message(struct hdhomerun_debug_t *dbg, struct hdhomerun_debug_message_t *message)
 {
@@ -466,7 +428,7 @@ static THREAD_FUNC_PREFIX hdhomerun_debug_thread_execute(void *arg)
 		pthread_mutex_unlock(&dbg->queue_lock);
 
 		if (!message) {
-			msleep(250);
+			msleep_approx(250);
 			continue;
 		}
 
@@ -476,7 +438,7 @@ static THREAD_FUNC_PREFIX hdhomerun_debug_thread_execute(void *arg)
 		}
 
 		if (!hdhomerun_debug_output_message(dbg, message)) {
-			msleep(250);
+			msleep_approx(250);
 			continue;
 		}
 

--- a/third_party/SiliconDust/libhdhomerun/hdhomerun_debug.h
+++ b/third_party/SiliconDust/libhdhomerun/hdhomerun_debug.h
@@ -3,10 +3,10 @@
  *
  * Copyright © 2006 Silicondust USA Inc. <www.silicondust.com>.
  *
- * This library is free software; you can redistribute it and/or 
+ * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
+ * version 2.1 of the License, or (at your option) any later version.
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -14,20 +14,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
- * 
- * As a special exception to the GNU Lesser General Public License,
- * you may link, statically or dynamically, an application with a
- * publicly distributed version of the Library to produce an
- * executable file containing portions of the Library, and
- * distribute that executable file under terms of your choice,
- * without any of the additional requirements listed in clause 4 of
- * the GNU Lesser General Public License.
- * 
- * By "a publicly distributed version of the Library", we mean
- * either the unmodified Library as distributed by Silicondust, or a
- * modified version of the Library that is distributed under the
- * conditions defined in the GNU Lesser General Public License.
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
 /*

--- a/third_party/SiliconDust/libhdhomerun/hdhomerun_device.c
+++ b/third_party/SiliconDust/libhdhomerun/hdhomerun_device.c
@@ -1,12 +1,12 @@
 /*
  * hdhomerun_device.c
  *
- * Copyright © 2006-2008 Silicondust USA Inc. <www.silicondust.com>.
+ * Copyright © 2006-2010 Silicondust USA Inc. <www.silicondust.com>.
  *
- * This library is free software; you can redistribute it and/or 
+ * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
+ * version 2.1 of the License, or (at your option) any later version.
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -14,20 +14,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
- * 
- * As a special exception to the GNU Lesser General Public License,
- * you may link, statically or dynamically, an application with a
- * publicly distributed version of the Library to produce an
- * executable file containing portions of the Library, and
- * distribute that executable file under terms of your choice,
- * without any of the additional requirements listed in clause 4 of
- * the GNU Lesser General Public License.
- * 
- * By "a publicly distributed version of the Library", we mean
- * either the unmodified Library as distributed by Silicondust, or a
- * modified version of the Library that is distributed under the
- * conditions defined in the GNU Lesser General Public License.
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
 #include "hdhomerun.h"
@@ -37,6 +25,8 @@ struct hdhomerun_device_t {
 	struct hdhomerun_video_sock_t *vs;
 	struct hdhomerun_debug_t *dbg;
 	struct hdhomerun_channelscan_t *scan;
+	uint32_t multicast_ip;
+	uint16_t multicast_port;
 	uint32_t device_id;
 	unsigned int tuner;
 	uint32_t lockkey;
@@ -44,172 +34,89 @@ struct hdhomerun_device_t {
 	char model[32];
 };
 
-static void hdhomerun_device_set_update(struct hdhomerun_device_t *hd)
+int hdhomerun_device_set_device(struct hdhomerun_device_t *hd, uint32_t device_id, uint32_t device_ip)
 {
-	/* Clear cached information. */
-	*hd->model = 0;
+	if ((device_id == 0) && (device_ip == 0)) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_set_device: device not specified\n");
+		return -1;
+	}
 
-	/* New name. */
-	sprintf(hd->name, "%08lX-%u", (unsigned long)hd->device_id, hd->tuner);
-}
+	if (hdhomerun_discover_is_ip_multicast(device_ip)) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_set_device: invalid address %08X\n", (unsigned int)device_ip);
+		return -1;
+	}
 
-void hdhomerun_device_set_device(struct hdhomerun_device_t *hd, uint32_t device_id, uint32_t device_ip)
-{
+	if (!hd->cs) {
+		hd->cs = hdhomerun_control_create(0, 0, hd->dbg);
+		if (!hd->cs) {
+			hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_set_device: failed to create control object\n");
+			return -1;
+		}
+	}
+
 	hdhomerun_control_set_device(hd->cs, device_id, device_ip);
 
 	if ((device_id == 0) || (device_id == HDHOMERUN_DEVICE_ID_WILDCARD)) {
 		device_id = hdhomerun_control_get_device_id(hd->cs);
 	}
 
+	hd->multicast_ip = 0;
+	hd->multicast_port = 0;
 	hd->device_id = device_id;
-	hdhomerun_device_set_update(hd);
+	hd->tuner = 0;
+	hd->lockkey = 0;
+
+	hdhomerun_sprintf(hd->name, hd->name + sizeof(hd->name), "%08X-%u", (unsigned int)hd->device_id, hd->tuner);
+	hdhomerun_sprintf(hd->model, hd->model + sizeof(hd->model), ""); /* clear cached model string */
+
+	return 1;
 }
 
-void hdhomerun_device_set_tuner(struct hdhomerun_device_t *hd, unsigned int tuner)
+int hdhomerun_device_set_multicast(struct hdhomerun_device_t *hd, uint32_t multicast_ip, uint16_t multicast_port)
 {
+	if (!hdhomerun_discover_is_ip_multicast(multicast_ip)) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_set_device_multicast: invalid address %08X\n", (unsigned int)multicast_ip);
+		return -1;
+	}
+
+	if (multicast_port == 0) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_set_device_multicast: invalid port %u\n", (unsigned int)multicast_port);
+		return -1;
+	}
+
+	if (hd->cs) {
+		hdhomerun_control_destroy(hd->cs);
+		hd->cs = NULL;
+	}
+
+	hd->multicast_ip = multicast_ip;
+	hd->multicast_port = multicast_port;
+	hd->device_id = 0;
+	hd->tuner = 0;
+	hd->lockkey = 0;
+
+	unsigned int ip = multicast_ip;
+	hdhomerun_sprintf(hd->name, hd->name + sizeof(hd->name), "%u.%u.%u.%u:%u", (ip >> 24) & 0xFF, (ip >> 16) & 0xFF, (ip >> 8) & 0xFF, (ip >> 0) & 0xFF, (unsigned int)multicast_port);
+	hdhomerun_sprintf(hd->model, hd->model + sizeof(hd->model), "multicast");
+
+	return 1;
+}
+
+int hdhomerun_device_set_tuner(struct hdhomerun_device_t *hd, unsigned int tuner)
+{
+	if (hd->multicast_ip != 0) {
+		if (tuner != 0) {
+			hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_set_tuner: tuner cannot be specified in multicast mode\n");
+			return -1;
+		}
+
+		return 1;
+	}
+
 	hd->tuner = tuner;
-	hdhomerun_device_set_update(hd);
-}
+	hdhomerun_sprintf(hd->name, hd->name + sizeof(hd->name), "%08X-%u", (unsigned int)hd->device_id, hd->tuner);
 
-struct hdhomerun_device_t *hdhomerun_device_create(uint32_t device_id, uint32_t device_ip, unsigned int tuner, struct hdhomerun_debug_t *dbg)
-{
-	struct hdhomerun_device_t *hd = (struct hdhomerun_device_t *)calloc(1, sizeof(struct hdhomerun_device_t));
-	if (!hd) {
-		hdhomerun_debug_printf(dbg, "hdhomerun_device_create: failed to allocate device object\n");
-		return NULL;
-	}
-
-	hd->dbg = dbg;
-
-	hd->cs = hdhomerun_control_create(0, 0, hd->dbg);
-	if (!hd->cs) {
-		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_create: failed to create control object\n");
-		free(hd);
-		return NULL;
-	}
-
-	hdhomerun_device_set_device(hd, device_id, device_ip);
-	hdhomerun_device_set_tuner(hd, tuner);
-
-	return hd;
-}
-
-void hdhomerun_device_destroy(struct hdhomerun_device_t *hd)
-{
-	if (hd->scan) {
-		channelscan_destroy(hd->scan);
-	}
-
-	if (hd->vs) {
-		hdhomerun_video_destroy(hd->vs);
-	}
-
-	hdhomerun_control_destroy(hd->cs);
-
-	free(hd);
-}
-
-static bool_t is_hex_char(char c)
-{
-	if ((c >= '0') && (c <= '9')) {
-		return TRUE;
-	}
-	if ((c >= 'A') && (c <= 'F')) {
-		return TRUE;
-	}
-	if ((c >= 'a') && (c <= 'f')) {
-		return TRUE;
-	}
-	return FALSE;
-}
-
-static struct hdhomerun_device_t *hdhomerun_device_create_from_str_device_id(const char *device_str, struct hdhomerun_debug_t *dbg)
-{
-	int i;
-	const char *ptr = device_str;
-	for (i = 0; i < 8; i++) {
-		if (!is_hex_char(*ptr++)) {
-			return NULL;
-		}
-	}
-
-	if (*ptr == 0) {
-		unsigned long device_id;
-		if (sscanf(device_str, "%lx", &device_id) != 1) {
-			return NULL;
-		}
-		return hdhomerun_device_create((uint32_t)device_id, 0, 0, dbg);
-	}
-
-	if (*ptr == '-') {
-		unsigned long device_id;
-		unsigned int tuner;
-		if (sscanf(device_str, "%lx-%u", &device_id, &tuner) != 2) {
-			return NULL;
-		}
-		return hdhomerun_device_create((uint32_t)device_id, 0, tuner, dbg);
-	}
-
-	return NULL;
-}
-
-static struct hdhomerun_device_t *hdhomerun_device_create_from_str_ip(const char *device_str, struct hdhomerun_debug_t *dbg)
-{
-	unsigned long a[4];
-	if (sscanf(device_str, "%lu.%lu.%lu.%lu", &a[0], &a[1], &a[2], &a[3]) != 4) {
-		return NULL;
-	}
-
-	unsigned long device_ip = (a[0] << 24) | (a[1] << 16) | (a[2] << 8) | (a[3] << 0);
-	return hdhomerun_device_create(HDHOMERUN_DEVICE_ID_WILDCARD, (uint32_t)device_ip, 0, dbg);
-}
-
-static struct hdhomerun_device_t *hdhomerun_device_create_from_str_dns(const char *device_str, struct hdhomerun_debug_t *dbg)
-{
-#if defined(__CYGWIN__)
-	return NULL;
-#else
-	struct addrinfo hints;
-	memset(&hints, 0, sizeof(hints));
-	hints.ai_family = AF_INET;
-	hints.ai_socktype = SOCK_STREAM;
-	hints.ai_protocol = IPPROTO_TCP;
-
-	struct addrinfo *sock_info;
-	if (getaddrinfo(device_str, "65001", &hints, &sock_info) != 0) {
-		return NULL;
-	}
-
-	struct sockaddr_in *sock_addr = (struct sockaddr_in *)sock_info->ai_addr;
-	uint32_t device_ip = ntohl(sock_addr->sin_addr.s_addr);
-	freeaddrinfo(sock_info);
-
-	if (device_ip == 0) {
-		return NULL;
-	}
-
-	return hdhomerun_device_create(HDHOMERUN_DEVICE_ID_WILDCARD, (uint32_t)device_ip, 0, dbg);
-#endif
-}
-
-struct hdhomerun_device_t *hdhomerun_device_create_from_str(const char *device_str, struct hdhomerun_debug_t *dbg)
-{
-	struct hdhomerun_device_t *device = hdhomerun_device_create_from_str_device_id(device_str, dbg);
-	if (device) {
-		return device;
-	}
-
-	device = hdhomerun_device_create_from_str_ip(device_str, dbg);
-	if (device) {
-		return device;
-	}
-
-	device = hdhomerun_device_create_from_str_dns(device_str, dbg);
-	if (device) {
-		return device;
-	}
-
-	return NULL;
+	return 1;
 }
 
 int hdhomerun_device_set_tuner_from_str(struct hdhomerun_device_t *hd, const char *tuner_str)
@@ -227,6 +134,149 @@ int hdhomerun_device_set_tuner_from_str(struct hdhomerun_device_t *hd, const cha
 	return -1;
 }
 
+static struct hdhomerun_device_t *hdhomerun_device_create_internal(struct hdhomerun_debug_t *dbg)
+{
+	struct hdhomerun_device_t *hd = (struct hdhomerun_device_t *)calloc(1, sizeof(struct hdhomerun_device_t));
+	if (!hd) {
+		hdhomerun_debug_printf(dbg, "hdhomerun_device_create: failed to allocate device object\n");
+		return NULL;
+	}
+
+	hd->dbg = dbg;
+	return hd;
+}
+
+struct hdhomerun_device_t *hdhomerun_device_create(uint32_t device_id, uint32_t device_ip, unsigned int tuner, struct hdhomerun_debug_t *dbg)
+{
+	struct hdhomerun_device_t *hd = hdhomerun_device_create_internal(dbg);
+	if (!hd) {
+		return NULL;
+	}
+
+	if ((device_id == 0) && (device_ip == 0) && (tuner == 0)) {
+		return hd;
+	}
+
+	if (hdhomerun_device_set_device(hd, device_id, device_ip) <= 0) {
+		free(hd);
+		return NULL;
+	}
+	if (hdhomerun_device_set_tuner(hd, tuner) <= 0) {
+		free(hd);
+		return NULL;
+	}
+
+	return hd;
+}
+
+struct hdhomerun_device_t *hdhomerun_device_create_multicast(uint32_t multicast_ip, uint16_t multicast_port, struct hdhomerun_debug_t *dbg)
+{
+	struct hdhomerun_device_t *hd = hdhomerun_device_create_internal(dbg);
+	if (!hd) {
+		return NULL;
+	}
+
+	if (hdhomerun_device_set_multicast(hd, multicast_ip, multicast_port) <= 0) {
+		free(hd);
+		return NULL;
+	}
+
+	return hd;
+}
+
+void hdhomerun_device_destroy(struct hdhomerun_device_t *hd)
+{
+	if (hd->scan) {
+		channelscan_destroy(hd->scan);
+	}
+
+	if (hd->vs) {
+		hdhomerun_video_destroy(hd->vs);
+	}
+
+	if (hd->cs) {
+		hdhomerun_control_destroy(hd->cs);
+	}
+
+	free(hd);
+}
+
+struct hdhomerun_device_t *hdhomerun_device_create_from_str(const char *device_str, struct hdhomerun_debug_t *dbg)
+{
+	/*
+	 * IP address based device_str.
+	 */
+	unsigned int a[4];
+	if (sscanf(device_str, "%u.%u.%u.%u", &a[0], &a[1], &a[2], &a[3]) == 4) {
+		uint32_t ip_addr = (uint32_t)((a[0] << 24) | (a[1] << 16) | (a[2] << 8) | (a[3] << 0));
+
+		/*
+		 * Multicast IP address.
+		 */
+		unsigned int port;
+		if (sscanf(device_str, "%u.%u.%u.%u:%u", &a[0], &a[1], &a[2], &a[3], &port) == 5) {
+			return hdhomerun_device_create_multicast(ip_addr, port, dbg);
+		}
+
+		/*
+		* IP address + tuner number.
+		*/
+		unsigned int tuner;
+		if (sscanf(device_str, "%u.%u.%u.%u-%u", &a[0], &a[1], &a[2], &a[3], &tuner) == 5) {
+			return hdhomerun_device_create(HDHOMERUN_DEVICE_ID_WILDCARD, ip_addr, tuner, dbg);
+		}
+
+		/*
+		 * IP address only.
+		 */
+		return hdhomerun_device_create(HDHOMERUN_DEVICE_ID_WILDCARD, ip_addr, 0, dbg);
+	}
+
+	/*
+	* Device ID based device_str.
+	*/
+	char *end;
+	uint32_t device_id = (uint32_t)strtoul(device_str, &end, 16);
+	if ((end == device_str + 8) && hdhomerun_discover_validate_device_id(device_id)) {
+		/*
+		 * IP address + tuner number.
+		 */
+		if (*end == '-') {
+			unsigned int tuner = (unsigned int)strtoul(end + 1, NULL, 10);
+			return hdhomerun_device_create(device_id, 0, tuner, dbg);
+		}
+
+		/*
+		 * Device ID only.
+		 */
+		return hdhomerun_device_create(device_id, 0, 0, dbg);
+	}
+
+	/*
+	 * DNS based device_str.
+	 */
+	struct addrinfo hints;
+	memset(&hints, 0, sizeof(hints));
+	hints.ai_family = AF_INET;
+	hints.ai_socktype = SOCK_STREAM;
+	hints.ai_protocol = IPPROTO_TCP;
+
+	struct addrinfo *sock_info;
+	if (getaddrinfo(device_str, "65001", &hints, &sock_info) != 0) {
+		return NULL;
+	}
+
+	struct sockaddr_in *sock_addr = (struct sockaddr_in *)sock_info->ai_addr;
+	uint32_t ip_addr = (uint32_t)ntohl(sock_addr->sin_addr.s_addr);
+	freeaddrinfo(sock_info);
+
+	if (ip_addr == 0) {
+		return NULL;
+	}
+
+	return hdhomerun_device_create(HDHOMERUN_DEVICE_ID_WILDCARD, ip_addr, 0, dbg);
+}
+
 const char *hdhomerun_device_get_name(struct hdhomerun_device_t *hd)
 {
 	return hd->name;
@@ -234,22 +284,43 @@ const char *hdhomerun_device_get_name(struct hdhomerun_device_t *hd)
 
 uint32_t hdhomerun_device_get_device_id(struct hdhomerun_device_t *hd)
 {
-	return hdhomerun_control_get_device_id(hd->cs);
+	return hd->device_id;
 }
 
 uint32_t hdhomerun_device_get_device_ip(struct hdhomerun_device_t *hd)
 {
-	return hdhomerun_control_get_device_ip(hd->cs);
+	if (hd->multicast_ip != 0) {
+		return hd->multicast_ip;
+	}
+	if (hd->cs) {
+		return hdhomerun_control_get_device_ip(hd->cs);
+	}
+
+	return 0;
 }
 
 uint32_t hdhomerun_device_get_device_id_requested(struct hdhomerun_device_t *hd)
 {
-	return hdhomerun_control_get_device_id_requested(hd->cs);
+	if (hd->multicast_ip != 0) {
+		return 0;
+	}
+	if (hd->cs) {
+		return hdhomerun_control_get_device_id_requested(hd->cs);
+	}
+
+	return 0;
 }
 
 uint32_t hdhomerun_device_get_device_ip_requested(struct hdhomerun_device_t *hd)
 {
-	return hdhomerun_control_get_device_ip_requested(hd->cs);
+	if (hd->multicast_ip != 0) {
+		return hd->multicast_ip;
+	}
+	if (hd->cs) {
+		return hdhomerun_control_get_device_ip_requested(hd->cs);
+	}
+
+	return 0;
 }
 
 unsigned int hdhomerun_device_get_tuner(struct hdhomerun_device_t *hd)
@@ -268,7 +339,9 @@ struct hdhomerun_video_sock_t *hdhomerun_device_get_video_sock(struct hdhomerun_
 		return hd->vs;
 	}
 
-	hd->vs = hdhomerun_video_create(0, VIDEO_DATA_BUFFER_SIZE_1S * 2, hd->dbg);
+	bool_t allow_port_reuse = (hd->multicast_port != 0);
+
+	hd->vs = hdhomerun_video_create(hd->multicast_port, allow_port_reuse, VIDEO_DATA_BUFFER_SIZE_1S * 2, hd->dbg);
 	if (!hd->vs) {
 		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_get_video_sock: failed to create video object\n");
 		return NULL;
@@ -279,7 +352,11 @@ struct hdhomerun_video_sock_t *hdhomerun_device_get_video_sock(struct hdhomerun_
 
 uint32_t hdhomerun_device_get_local_machine_addr(struct hdhomerun_device_t *hd)
 {
-	return hdhomerun_control_get_local_addr(hd->cs);
+	if (hd->cs) {
+		return hdhomerun_control_get_local_addr(hd->cs);
+	}
+
+	return 0;
 }
 
 static uint32_t hdhomerun_device_get_status_parse(const char *status_str, const char *tag)
@@ -289,8 +366,8 @@ static uint32_t hdhomerun_device_get_status_parse(const char *status_str, const 
 		return 0;
 	}
 
-	unsigned long value = 0;
-	sscanf(ptr + strlen(tag), "%lu", &value);
+	unsigned int value = 0;
+	sscanf(ptr + strlen(tag), "%u", &value);
 
 	return (uint32_t)value;
 }
@@ -363,10 +440,15 @@ uint32_t hdhomerun_device_get_tuner_status_seq_color(struct hdhomerun_tuner_stat
 
 int hdhomerun_device_get_tuner_status(struct hdhomerun_device_t *hd, char **pstatus_str, struct hdhomerun_tuner_status_t *status)
 {
+	if (!hd->cs) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_get_tuner_status: device not set\n");
+		return -1;
+	}
+
 	memset(status, 0, sizeof(struct hdhomerun_tuner_status_t));
 
 	char name[32];
-	sprintf(name, "/tuner%u/status", hd->tuner);
+	hdhomerun_sprintf(name, name + sizeof(name), "/tuner%u/status", hd->tuner);
 
 	char *status_str;
 	int ret = hdhomerun_control_get(hd->cs, name, &status_str, NULL);
@@ -378,29 +460,140 @@ int hdhomerun_device_get_tuner_status(struct hdhomerun_device_t *hd, char **psta
 		*pstatus_str = status_str;
 	}
 
-	char *channel = strstr(status_str, "ch=");
-	if (channel) {
-		sscanf(channel + 3, "%31s", status->channel);
+	if (status) {
+		char *channel = strstr(status_str, "ch=");
+		if (channel) {
+			sscanf(channel + 3, "%31s", status->channel);
+		}
+
+		char *lock = strstr(status_str, "lock=");
+		if (lock) {
+			sscanf(lock + 5, "%31s", status->lock_str);
+		}
+
+		status->signal_strength = (unsigned int)hdhomerun_device_get_status_parse(status_str, "ss=");
+		status->signal_to_noise_quality = (unsigned int)hdhomerun_device_get_status_parse(status_str, "snq=");
+		status->symbol_error_quality = (unsigned int)hdhomerun_device_get_status_parse(status_str, "seq=");
+		status->raw_bits_per_second = hdhomerun_device_get_status_parse(status_str, "bps=");
+		status->packets_per_second = hdhomerun_device_get_status_parse(status_str, "pps=");
+
+		status->signal_present = status->signal_strength >= 45;
+
+		if (strcmp(status->lock_str, "none") != 0) {
+			if (status->lock_str[0] == '(') {
+				status->lock_unsupported = TRUE;
+			} else {
+				status->lock_supported = TRUE;
+			}
+		}
 	}
 
-	char *lock = strstr(status_str, "lock=");
-	if (lock) {
-		sscanf(lock + 5, "%31s", status->lock_str);
+	return 1;
+}
+
+int hdhomerun_device_get_oob_status(struct hdhomerun_device_t *hd, char **pstatus_str, struct hdhomerun_tuner_status_t *status)
+{
+	if (!hd->cs) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_get_oob_status: device not set\n");
+		return -1;
 	}
 
-	status->signal_strength = (unsigned int)hdhomerun_device_get_status_parse(status_str, "ss=");
-	status->signal_to_noise_quality = (unsigned int)hdhomerun_device_get_status_parse(status_str, "snq=");
-	status->symbol_error_quality = (unsigned int)hdhomerun_device_get_status_parse(status_str, "seq=");
-	status->raw_bits_per_second = hdhomerun_device_get_status_parse(status_str, "bps=");
-	status->packets_per_second = hdhomerun_device_get_status_parse(status_str, "pps=");
+	memset(status, 0, sizeof(struct hdhomerun_tuner_status_t));
 
-	status->signal_present = status->signal_strength >= 45;
+	char *status_str;
+	int ret = hdhomerun_control_get(hd->cs, "/oob/status", &status_str, NULL);
+	if (ret <= 0) {
+		return ret;
+	}
 
-	if (strcmp(status->lock_str, "none") != 0) {
-		if (status->lock_str[0] == '(') {
-			status->lock_unsupported = TRUE;
-		} else {
-			status->lock_supported = TRUE;
+	if (pstatus_str) {
+		*pstatus_str = status_str;
+	}
+
+	if (status) {
+		char *channel = strstr(status_str, "ch=");
+		if (channel) {
+			sscanf(channel + 3, "%31s", status->channel);
+		}
+
+		char *lock = strstr(status_str, "lock=");
+		if (lock) {
+			sscanf(lock + 5, "%31s", status->lock_str);
+		}
+
+		status->signal_strength = (unsigned int)hdhomerun_device_get_status_parse(status_str, "ss=");
+		status->signal_to_noise_quality = (unsigned int)hdhomerun_device_get_status_parse(status_str, "snq=");
+		status->signal_present = status->signal_strength >= 45;
+		status->lock_supported = (strcmp(status->lock_str, "none") != 0);
+	}
+
+	return 1;
+}
+
+int hdhomerun_device_get_tuner_vstatus(struct hdhomerun_device_t *hd, char **pvstatus_str, struct hdhomerun_tuner_vstatus_t *vstatus)
+{
+	if (!hd->cs) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_get_tuner_vstatus: device not set\n");
+		return -1;
+	}
+
+	memset(vstatus, 0, sizeof(struct hdhomerun_tuner_vstatus_t));
+
+	char var_name[32];
+	hdhomerun_sprintf(var_name, var_name + sizeof(var_name), "/tuner%u/vstatus", hd->tuner);
+
+	char *vstatus_str;
+	int ret = hdhomerun_control_get(hd->cs, var_name, &vstatus_str, NULL);
+	if (ret <= 0) {
+		return ret;
+	}
+
+	if (pvstatus_str) {
+		*pvstatus_str = vstatus_str;
+	}
+
+	if (vstatus) {
+		char *vch = strstr(vstatus_str, "vch=");
+		if (vch) {
+			sscanf(vch + 4, "%31s", vstatus->vchannel);
+		}
+
+		char *name = strstr(vstatus_str, "name=");
+		if (name) {
+			sscanf(name + 5, "%31s", vstatus->name);
+		}
+
+		char *auth = strstr(vstatus_str, "auth=");
+		if (auth) {
+			sscanf(auth + 5, "%31s", vstatus->auth);
+		}
+
+		char *cci = strstr(vstatus_str, "cci=");
+		if (cci) {
+			sscanf(cci + 4, "%31s", vstatus->cci);
+		}
+
+		char *cgms = strstr(vstatus_str, "cgms=");
+		if (cgms) {
+			sscanf(cgms + 5, "%31s", vstatus->cgms);
+		}
+
+		if (strncmp(vstatus->auth, "not-subscribed", 14) == 0) {
+			vstatus->not_subscribed = TRUE;
+		}
+
+		if (strncmp(vstatus->auth, "error", 5) == 0) {
+			vstatus->not_available = TRUE;
+		}
+		if (strncmp(vstatus->auth, "dialog", 6) == 0) {
+			vstatus->not_available = TRUE;
+		}
+
+		if (strncmp(vstatus->cci, "protected", 9) == 0) {
+			vstatus->copy_protected = TRUE;
+		}
+		if (strncmp(vstatus->cgms, "protected", 9) == 0) {
+			vstatus->copy_protected = TRUE;
 		}
 	}
 
@@ -409,51 +602,90 @@ int hdhomerun_device_get_tuner_status(struct hdhomerun_device_t *hd, char **psta
 
 int hdhomerun_device_get_tuner_streaminfo(struct hdhomerun_device_t *hd, char **pstreaminfo)
 {
+	if (!hd->cs) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_get_tuner_streaminfo: device not set\n");
+		return -1;
+	}
+
 	char name[32];
-	sprintf(name, "/tuner%u/streaminfo", hd->tuner);
+	hdhomerun_sprintf(name, name + sizeof(name), "/tuner%u/streaminfo", hd->tuner);
 	return hdhomerun_control_get(hd->cs, name, pstreaminfo, NULL);
 }
 
 int hdhomerun_device_get_tuner_channel(struct hdhomerun_device_t *hd, char **pchannel)
 {
+	if (!hd->cs) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_get_tuner_channel: device not set\n");
+		return -1;
+	}
+
 	char name[32];
-	sprintf(name, "/tuner%u/channel", hd->tuner);
+	hdhomerun_sprintf(name, name + sizeof(name), "/tuner%u/channel", hd->tuner);
 	return hdhomerun_control_get(hd->cs, name, pchannel, NULL);
+}
+
+int hdhomerun_device_get_tuner_vchannel(struct hdhomerun_device_t *hd, char **pvchannel)
+{
+	if (!hd->cs) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_get_tuner_vchannel: device not set\n");
+		return -1;
+	}
+
+	char name[32];
+	hdhomerun_sprintf(name, name + sizeof(name), "/tuner%u/vchannel", hd->tuner);
+	return hdhomerun_control_get(hd->cs, name, pvchannel, NULL);
 }
 
 int hdhomerun_device_get_tuner_channelmap(struct hdhomerun_device_t *hd, char **pchannelmap)
 {
+	if (!hd->cs) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_get_tuner_channelmap: device not set\n");
+		return -1;
+	}
+
 	char name[32];
-	sprintf(name, "/tuner%u/channelmap", hd->tuner);
+	hdhomerun_sprintf(name, name + sizeof(name), "/tuner%u/channelmap", hd->tuner);
 	return hdhomerun_control_get(hd->cs, name, pchannelmap, NULL);
 }
 
 int hdhomerun_device_get_tuner_filter(struct hdhomerun_device_t *hd, char **pfilter)
 {
+	if (!hd->cs) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_get_tuner_filter: device not set\n");
+		return -1;
+	}
+
 	char name[32];
-	sprintf(name, "/tuner%u/filter", hd->tuner);
+	hdhomerun_sprintf(name, name + sizeof(name), "/tuner%u/filter", hd->tuner);
 	return hdhomerun_control_get(hd->cs, name, pfilter, NULL);
 }
 
 int hdhomerun_device_get_tuner_program(struct hdhomerun_device_t *hd, char **pprogram)
 {
+	if (!hd->cs) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_get_tuner_program: device not set\n");
+		return -1;
+	}
+
 	char name[32];
-	sprintf(name, "/tuner%u/program", hd->tuner);
+	hdhomerun_sprintf(name, name + sizeof(name), "/tuner%u/program", hd->tuner);
 	return hdhomerun_control_get(hd->cs, name, pprogram, NULL);
 }
 
 int hdhomerun_device_get_tuner_target(struct hdhomerun_device_t *hd, char **ptarget)
 {
+	if (!hd->cs) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_get_tuner_target: device not set\n");
+		return -1;
+	}
+
 	char name[32];
-	sprintf(name, "/tuner%u/target", hd->tuner);
+	hdhomerun_sprintf(name, name + sizeof(name), "/tuner%u/target", hd->tuner);
 	return hdhomerun_control_get(hd->cs, name, ptarget, NULL);
 }
 
-int hdhomerun_device_get_tuner_plotsample(struct hdhomerun_device_t *hd, struct hdhomerun_plotsample_t **psamples, size_t *pcount)
+static int hdhomerun_device_get_tuner_plotsample_internal(struct hdhomerun_device_t *hd, const char *name, struct hdhomerun_plotsample_t **psamples, size_t *pcount)
 {
-	char name[32];
-	sprintf(name, "/tuner%u/plotsample", hd->tuner);
-
 	char *result;
 	int ret = hdhomerun_control_get(hd->cs, name, &result, NULL);
 	if (ret <= 0) {
@@ -471,8 +703,8 @@ int hdhomerun_device_get_tuner_plotsample(struct hdhomerun_device_t *hd, struct 
 		}
 		*ptr++ = 0;
 
-		unsigned long raw;
-		if (sscanf(result, "%lx", &raw) != 1) {
+		unsigned int raw;
+		if (sscanf(result, "%x", &raw) != 1) {
 			break;
 		}
 
@@ -498,25 +730,57 @@ int hdhomerun_device_get_tuner_plotsample(struct hdhomerun_device_t *hd, struct 
 	return 1;
 }
 
+int hdhomerun_device_get_tuner_plotsample(struct hdhomerun_device_t *hd, struct hdhomerun_plotsample_t **psamples, size_t *pcount)
+{
+	if (!hd->cs) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_get_tuner_plotsample: device not set\n");
+		return -1;
+	}
+
+	char name[32];
+	hdhomerun_sprintf(name, name + sizeof(name), "/tuner%u/plotsample", hd->tuner);
+	return hdhomerun_device_get_tuner_plotsample_internal(hd, name, psamples, pcount);
+}
+
+int hdhomerun_device_get_oob_plotsample(struct hdhomerun_device_t *hd, struct hdhomerun_plotsample_t **psamples, size_t *pcount)
+{
+	if (!hd->cs) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_get_oob_plotsample: device not set\n");
+		return -1;
+	}
+
+	return hdhomerun_device_get_tuner_plotsample_internal(hd, "/oob/plotsample", psamples, pcount);
+}
+
 int hdhomerun_device_get_tuner_lockkey_owner(struct hdhomerun_device_t *hd, char **powner)
 {
+	if (!hd->cs) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_get_tuner_lockkey_owner: device not set\n");
+		return -1;
+	}
+
 	char name[32];
-	sprintf(name, "/tuner%u/lockkey", hd->tuner);
+	hdhomerun_sprintf(name, name + sizeof(name), "/tuner%u/lockkey", hd->tuner);
 	return hdhomerun_control_get(hd->cs, name, powner, NULL);
 }
 
 int hdhomerun_device_get_ir_target(struct hdhomerun_device_t *hd, char **ptarget)
 {
-	return hdhomerun_control_get(hd->cs, "/ir/target", ptarget, NULL);
-}
+	if (!hd->cs) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_get_ir_target: device not set\n");
+		return -1;
+	}
 
-int hdhomerun_device_get_lineup_location(struct hdhomerun_device_t *hd, char **plocation)
-{
-	return hdhomerun_control_get(hd->cs, "/lineup/location", plocation, NULL);
+	return hdhomerun_control_get(hd->cs, "/ir/target", ptarget, NULL);
 }
 
 int hdhomerun_device_get_version(struct hdhomerun_device_t *hd, char **pversion_str, uint32_t *pversion_num)
 {
+	if (!hd->cs) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_get_version: device not set\n");
+		return -1;
+	}
+
 	char *version_str;
 	int ret = hdhomerun_control_get(hd->cs, "/sys/version", &version_str, NULL);
 	if (ret <= 0) {
@@ -528,8 +792,8 @@ int hdhomerun_device_get_version(struct hdhomerun_device_t *hd, char **pversion_
 	}
 
 	if (pversion_num) {
-		unsigned long version_num;
-		if (sscanf(version_str, "%lu", &version_num) != 1) {
+		unsigned int version_num;
+		if (sscanf(version_str, "%u", &version_num) != 1) {
 			*pversion_num = 0;
 		} else {
 			*pversion_num = (uint32_t)version_num;
@@ -539,46 +803,95 @@ int hdhomerun_device_get_version(struct hdhomerun_device_t *hd, char **pversion_
 	return 1;
 }
 
+int hdhomerun_device_get_supported(struct hdhomerun_device_t *hd, char *prefix, char **pstr)
+{
+	if (!hd->cs) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_set_tuner_channel: device not set\n");
+		return -1;
+	}
+
+	char *features;
+	int ret = hdhomerun_control_get(hd->cs, "/sys/features", &features, NULL);
+	if (ret <= 0) {
+		return ret;
+	}
+
+	if (!prefix) {
+		*pstr = features;
+		return 1;
+	}
+
+	char *ptr = strstr(features, prefix);
+	if (!ptr) {
+		return 0;
+	}
+
+	ptr += strlen(prefix);
+	*pstr = ptr;
+
+	ptr = strchr(ptr, '\n');
+	if (ptr) {
+		*ptr = 0;
+	}
+
+	return 1;
+}
+
 int hdhomerun_device_set_tuner_channel(struct hdhomerun_device_t *hd, const char *channel)
 {
+	if (!hd->cs) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_set_tuner_channel: device not set\n");
+		return -1;
+	}
+
 	char name[32];
-	sprintf(name, "/tuner%u/channel", hd->tuner);
+	hdhomerun_sprintf(name, name + sizeof(name), "/tuner%u/channel", hd->tuner);
 	return hdhomerun_control_set_with_lockkey(hd->cs, name, channel, hd->lockkey, NULL, NULL);
+}
+
+int hdhomerun_device_set_tuner_vchannel(struct hdhomerun_device_t *hd, const char *vchannel)
+{
+	if (!hd->cs) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_set_tuner_vchannel: device not set\n");
+		return -1;
+	}
+
+	char name[32];
+	hdhomerun_sprintf(name, name + sizeof(name), "/tuner%u/vchannel", hd->tuner);
+	return hdhomerun_control_set_with_lockkey(hd->cs, name, vchannel, hd->lockkey, NULL, NULL);
 }
 
 int hdhomerun_device_set_tuner_channelmap(struct hdhomerun_device_t *hd, const char *channelmap)
 {
+	if (!hd->cs) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_set_tuner_channelmap: device not set\n");
+		return -1;
+	}
+
 	char name[32];
-	sprintf(name, "/tuner%u/channelmap", hd->tuner);
+	hdhomerun_sprintf(name, name + sizeof(name), "/tuner%u/channelmap", hd->tuner);
 	return hdhomerun_control_set_with_lockkey(hd->cs, name, channelmap, hd->lockkey, NULL, NULL);
 }
 
 int hdhomerun_device_set_tuner_filter(struct hdhomerun_device_t *hd, const char *filter)
 {
+	if (!hd->cs) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_set_tuner_filter: device not set\n");
+		return -1;
+	}
+
 	char name[32];
-	sprintf(name, "/tuner%u/filter", hd->tuner);
+	hdhomerun_sprintf(name, name + sizeof(name), "/tuner%u/filter", hd->tuner);
 	return hdhomerun_control_set_with_lockkey(hd->cs, name, filter, hd->lockkey, NULL, NULL);
 }
 
-static int hdhomerun_device_set_tuner_filter_by_array_append(char **pptr, char *end, uint16_t range_begin, uint16_t range_end)
+static bool_t hdhomerun_device_set_tuner_filter_by_array_append(char *ptr, char *end, uint16_t range_begin, uint16_t range_end)
 {
-	char *ptr = *pptr;
-
-	size_t available = end - ptr;
-	size_t required;
-
 	if (range_begin == range_end) {
-		required = snprintf(ptr, available, "0x%04x ", range_begin) + 1;
+		return hdhomerun_sprintf(ptr, end, "0x%04x ", (unsigned int)range_begin);
 	} else {
-		required = snprintf(ptr, available, "0x%04x-0x%04x ", range_begin, range_end) + 1;
+		return hdhomerun_sprintf(ptr, end, "0x%04x-0x%04x ", (unsigned int)range_begin, (unsigned int)range_end);
 	}
-
-	if (required > available) {
-		return FALSE;
-	}
-
-	*pptr = strchr(ptr, 0);
-	return TRUE;
 }
 
 int hdhomerun_device_set_tuner_filter_by_array(struct hdhomerun_device_t *hd, unsigned char filter_array[0x2000])
@@ -596,9 +909,10 @@ int hdhomerun_device_set_tuner_filter_by_array(struct hdhomerun_device_t *hd, un
 			if (range_begin == 0xFFFF) {
 				continue;
 			}
-			if (!hdhomerun_device_set_tuner_filter_by_array_append(&ptr, end, range_begin, range_end)) {
+			if (!hdhomerun_device_set_tuner_filter_by_array_append(ptr, end, range_begin, range_end)) {
 				return 0;
 			}
+			ptr = strchr(ptr, 0);
 			range_begin = 0xFFFF;
 			range_end = 0xFFFF;
 			continue;
@@ -614,39 +928,53 @@ int hdhomerun_device_set_tuner_filter_by_array(struct hdhomerun_device_t *hd, un
 	}
 
 	if (range_begin != 0xFFFF) {
-		if (!hdhomerun_device_set_tuner_filter_by_array_append(&ptr, end, range_begin, range_end)) {
+		if (!hdhomerun_device_set_tuner_filter_by_array_append(ptr, end, range_begin, range_end)) {
 			return 0;
 		}
+		ptr = strchr(ptr, 0);
 	}
 
 	/* Remove trailing space. */
 	if (ptr > filter) {
 		ptr--;
+		*ptr = 0;
 	}
-	*ptr = 0;
 
 	return hdhomerun_device_set_tuner_filter(hd, filter);
 }
 
 int hdhomerun_device_set_tuner_program(struct hdhomerun_device_t *hd, const char *program)
 {
+	if (!hd->cs) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_set_tuner_program: device not set\n");
+		return -1;
+	}
+
 	char name[32];
-	sprintf(name, "/tuner%u/program", hd->tuner);
+	hdhomerun_sprintf(name, name + sizeof(name), "/tuner%u/program", hd->tuner);
 	return hdhomerun_control_set_with_lockkey(hd->cs, name, program, hd->lockkey, NULL, NULL);
 }
 
 int hdhomerun_device_set_tuner_target(struct hdhomerun_device_t *hd, const char *target)
 {
+	if (!hd->cs) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_set_tuner_target: device not set\n");
+		return -1;
+	}
+
 	char name[32];
-	sprintf(name, "/tuner%u/target", hd->tuner);
+	hdhomerun_sprintf(name, name + sizeof(name), "/tuner%u/target", hd->tuner);
 	return hdhomerun_control_set_with_lockkey(hd->cs, name, target, hd->lockkey, NULL, NULL);
 }
 
-int hdhomerun_device_set_tuner_target_to_local_protocol(struct hdhomerun_device_t *hd, const char *protocol)
+static int hdhomerun_device_set_tuner_target_to_local(struct hdhomerun_device_t *hd, const char *protocol)
 {
-	/* Create video socket. */
-	hdhomerun_device_get_video_sock(hd);
+	if (!hd->cs) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_set_tuner_target_to_local: device not set\n");
+		return -1;
+	}
 	if (!hd->vs) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_set_tuner_target_to_local: video not initialized\n");
 		return -1;
 	}
 
@@ -654,7 +982,7 @@ int hdhomerun_device_set_tuner_target_to_local_protocol(struct hdhomerun_device_
 	char target[64];
 	uint32_t local_ip = hdhomerun_control_get_local_addr(hd->cs);
 	uint16_t local_port = hdhomerun_video_get_local_port(hd->vs);
-	sprintf(target, "%s://%u.%u.%u.%u:%u",
+	hdhomerun_sprintf(target, target + sizeof(target), "%s://%u.%u.%u.%u:%u",
 		protocol,
 		(unsigned int)(local_ip >> 24) & 0xFF, (unsigned int)(local_ip >> 16) & 0xFF,
 		(unsigned int)(local_ip >> 8) & 0xFF, (unsigned int)(local_ip >> 0) & 0xFF,
@@ -664,40 +992,63 @@ int hdhomerun_device_set_tuner_target_to_local_protocol(struct hdhomerun_device_
 	return hdhomerun_device_set_tuner_target(hd, target);
 }
 
-int hdhomerun_device_set_tuner_target_to_local(struct hdhomerun_device_t *hd)
-{
-	return hdhomerun_device_set_tuner_target_to_local_protocol(hd, HDHOMERUN_TARGET_PROTOCOL_UDP); 
-}
-
 int hdhomerun_device_set_ir_target(struct hdhomerun_device_t *hd, const char *target)
 {
+	if (!hd->cs) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_set_ir_target: device not set\n");
+		return -1;
+	}
+
 	return hdhomerun_control_set(hd->cs, "/ir/target", target, NULL, NULL);
 }
 
-int hdhomerun_device_set_lineup_location(struct hdhomerun_device_t *hd, const char *location)
+int hdhomerun_device_set_sys_dvbc_modulation(struct hdhomerun_device_t *hd, const char *modulation_list)
 {
-	return hdhomerun_control_set(hd->cs, "/lineup/location", location, NULL, NULL);
+	if (!hd->cs) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_set_sys_dvbc_modulation: device not set\n");
+		return -1;
+	}
+
+	return hdhomerun_control_set(hd->cs, "/sys/dvbc_modulation", modulation_list, NULL, NULL);
 }
 
 int hdhomerun_device_get_var(struct hdhomerun_device_t *hd, const char *name, char **pvalue, char **perror)
 {
+	if (!hd->cs) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_get_var: device not set\n");
+		return -1;
+	}
+
 	return hdhomerun_control_get(hd->cs, name, pvalue, perror);
 }
 
 int hdhomerun_device_set_var(struct hdhomerun_device_t *hd, const char *name, const char *value, char **pvalue, char **perror)
 {
+	if (!hd->cs) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_set_var: device not set\n");
+		return -1;
+	}
+
 	return hdhomerun_control_set_with_lockkey(hd->cs, name, value, hd->lockkey, pvalue, perror);
 }
 
 int hdhomerun_device_tuner_lockkey_request(struct hdhomerun_device_t *hd, char **perror)
 {
-	uint32_t new_lockkey = (uint32_t)getcurrenttime();
+	if (hd->multicast_ip != 0) {
+		return 1;
+	}
+	if (!hd->cs) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_tuner_lockkey_request: device not set\n");
+		return -1;
+	}
+
+	uint32_t new_lockkey = random_get32();
 
 	char name[32];
-	sprintf(name, "/tuner%u/lockkey", hd->tuner);
+	hdhomerun_sprintf(name, name + sizeof(name), "/tuner%u/lockkey", hd->tuner);
 
 	char new_lockkey_str[64];
-	sprintf(new_lockkey_str, "%u", (unsigned int)new_lockkey);
+	hdhomerun_sprintf(new_lockkey_str, new_lockkey_str + sizeof(new_lockkey_str), "%u", (unsigned int)new_lockkey);
 
 	int ret = hdhomerun_control_set_with_lockkey(hd->cs, name, new_lockkey_str, hd->lockkey, NULL, perror);
 	if (ret <= 0) {
@@ -711,12 +1062,20 @@ int hdhomerun_device_tuner_lockkey_request(struct hdhomerun_device_t *hd, char *
 
 int hdhomerun_device_tuner_lockkey_release(struct hdhomerun_device_t *hd)
 {
+	if (hd->multicast_ip != 0) {
+		return 1;
+	}
+	if (!hd->cs) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_tuner_lockkey_release: device not set\n");
+		return -1;
+	}
+
 	if (hd->lockkey == 0) {
 		return 1;
 	}
 
 	char name[32];
-	sprintf(name, "/tuner%u/lockkey", hd->tuner);
+	hdhomerun_sprintf(name, name + sizeof(name), "/tuner%u/lockkey", hd->tuner);
 	int ret = hdhomerun_control_set_with_lockkey(hd->cs, name, "none", hd->lockkey, NULL, NULL);
 
 	hd->lockkey = 0;
@@ -725,8 +1084,16 @@ int hdhomerun_device_tuner_lockkey_release(struct hdhomerun_device_t *hd)
 
 int hdhomerun_device_tuner_lockkey_force(struct hdhomerun_device_t *hd)
 {
+	if (hd->multicast_ip != 0) {
+		return 1;
+	}
+	if (!hd->cs) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_tuner_lockkey_force: device not set\n");
+		return -1;
+	}
+
 	char name[32];
-	sprintf(name, "/tuner%u/lockkey", hd->tuner);
+	hdhomerun_sprintf(name, name + sizeof(name), "/tuner%u/lockkey", hd->tuner);
 	int ret = hdhomerun_control_set(hd->cs, name, "force", NULL, NULL);
 
 	hd->lockkey = 0;
@@ -735,13 +1102,17 @@ int hdhomerun_device_tuner_lockkey_force(struct hdhomerun_device_t *hd)
 
 void hdhomerun_device_tuner_lockkey_use_value(struct hdhomerun_device_t *hd, uint32_t lockkey)
 {
+	if (hd->multicast_ip != 0) {
+		return;
+	}
+
 	hd->lockkey = lockkey;
 }
 
 int hdhomerun_device_wait_for_lock(struct hdhomerun_device_t *hd, struct hdhomerun_tuner_status_t *status)
 {
 	/* Delay for SS reading to be valid (signal present). */
-	msleep(250);
+	msleep_minimum(250);
 
 	/* Wait for up to 2.5 seconds for lock. */
 	uint64_t timeout = getcurrenttime() + 2500;
@@ -763,51 +1134,73 @@ int hdhomerun_device_wait_for_lock(struct hdhomerun_device_t *hd, struct hdhomer
 			return 1;
 		}
 
-		msleep(250);
+		msleep_approx(250);
 	}
 }
 
 int hdhomerun_device_stream_start(struct hdhomerun_device_t *hd)
 {
+	hdhomerun_device_get_video_sock(hd);
+	if (!hd->vs) {
+		return -1;
+	}
+
 	/* Set target. */
-	int ret = hdhomerun_device_stream_refresh_target(hd);
-	if (ret <= 0) {
-		return ret;
+	if (hd->multicast_ip != 0) {
+		int ret = hdhomerun_video_join_multicast_group(hd->vs, hd->multicast_ip, 0);
+		if (ret <= 0) {
+			return ret;
+		}
+	} else {
+		int ret = hdhomerun_device_set_tuner_target_to_local(hd, HDHOMERUN_TARGET_PROTOCOL_RTP);
+		if (ret == 0) {
+			ret = hdhomerun_device_set_tuner_target_to_local(hd, HDHOMERUN_TARGET_PROTOCOL_UDP);
+		}
+		if (ret <= 0) {
+			return ret;
+		}
 	}
 
 	/* Flush video buffer. */
-	msleep(64);
+	msleep_minimum(64);
 	hdhomerun_video_flush(hd->vs);
 
 	/* Success. */
 	return 1;
 }
 
-int hdhomerun_device_stream_refresh_target(struct hdhomerun_device_t *hd)
-{
-	int ret = hdhomerun_device_set_tuner_target_to_local_protocol(hd, HDHOMERUN_TARGET_PROTOCOL_RTP);
-	if (ret == 0) {
-		ret = hdhomerun_device_set_tuner_target_to_local_protocol(hd, HDHOMERUN_TARGET_PROTOCOL_UDP);
-	}
-	return ret;
-}
-
 uint8_t *hdhomerun_device_stream_recv(struct hdhomerun_device_t *hd, size_t max_size, size_t *pactual_size)
 {
 	if (!hd->vs) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_stream_recv: video not initialized\n");
 		return NULL;
 	}
+
 	return hdhomerun_video_recv(hd->vs, max_size, pactual_size);
 }
 
 void hdhomerun_device_stream_flush(struct hdhomerun_device_t *hd)
 {
+	if (!hd->vs) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_stream_flush: video not initialized\n");
+		return;
+	}
+
 	hdhomerun_video_flush(hd->vs);
 }
 
 void hdhomerun_device_stream_stop(struct hdhomerun_device_t *hd)
 {
-	hdhomerun_device_set_tuner_target(hd, "none");
+	if (!hd->vs) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_stream_stop: video not initialized\n");
+		return;
+	}
+
+	if (hd->multicast_ip != 0) {
+		hdhomerun_video_leave_multicast_group(hd->vs, hd->multicast_ip, 0);
+	} else {
+		hdhomerun_device_set_tuner_target(hd, "none");
+	}
 }
 
 int hdhomerun_device_channelscan_init(struct hdhomerun_device_t *hd, const char *channelmap)
@@ -818,6 +1211,7 @@ int hdhomerun_device_channelscan_init(struct hdhomerun_device_t *hd, const char 
 
 	hd->scan = channelscan_create(hd, channelmap);
 	if (!hd->scan) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_channelscan_init: failed to create scan object\n");
 		return -1;
 	}
 
@@ -827,11 +1221,12 @@ int hdhomerun_device_channelscan_init(struct hdhomerun_device_t *hd, const char 
 int hdhomerun_device_channelscan_advance(struct hdhomerun_device_t *hd, struct hdhomerun_channelscan_result_t *result)
 {
 	if (!hd->scan) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_channelscan_advance: scan not initialized\n");
 		return 0;
 	}
 
 	int ret = channelscan_advance(hd->scan, result);
-	if (ret <= 0) {
+	if (ret <= 0) { /* Free scan if normal finish or fatal error */
 		channelscan_destroy(hd->scan);
 		hd->scan = NULL;
 	}
@@ -842,11 +1237,12 @@ int hdhomerun_device_channelscan_advance(struct hdhomerun_device_t *hd, struct h
 int hdhomerun_device_channelscan_detect(struct hdhomerun_device_t *hd, struct hdhomerun_channelscan_result_t *result)
 {
 	if (!hd->scan) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_channelscan_detect: scan not initialized\n");
 		return 0;
 	}
 
 	int ret = channelscan_detect(hd->scan, result);
-	if (ret <= 0) {
+	if (ret < 0) { /* Free scan if fatal error */
 		channelscan_destroy(hd->scan);
 		hd->scan = NULL;
 	}
@@ -857,30 +1253,38 @@ int hdhomerun_device_channelscan_detect(struct hdhomerun_device_t *hd, struct hd
 uint8_t hdhomerun_device_channelscan_get_progress(struct hdhomerun_device_t *hd)
 {
 	if (!hd->scan) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_channelscan_get_progress: scan not initialized\n");
 		return 0;
 	}
 
 	return channelscan_get_progress(hd->scan);
 }
 
-int hdhomerun_device_firmware_version_check(struct hdhomerun_device_t *hd, uint32_t features)
+const char *hdhomerun_device_get_hw_model_str(struct hdhomerun_device_t *hd)
 {
-	uint32_t version;
-	if (hdhomerun_device_get_version(hd, NULL, &version) <= 0) {
-		return -1;
-	}
+    if (!hd->cs) {
+        hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_get_hw_model_str: device not set\n");
+        return NULL;
+    }
 
-	if (version < 20070219) {
-		return 0;
-	}
-
-	return 1;
+    char *model_str;
+    int ret = hdhomerun_control_get(hd->cs, "/sys/hwmodel", &model_str, NULL);
+    if (ret < 0) {
+        return NULL;
+    }
+    return model_str;
 }
+
 
 const char *hdhomerun_device_get_model_str(struct hdhomerun_device_t *hd)
 {
 	if (*hd->model) {
 		return hd->model;
+	}
+
+	if (!hd->cs) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_get_model_str: device not set\n");
+		return NULL;
 	}
 
 	char *model_str;
@@ -889,17 +1293,21 @@ const char *hdhomerun_device_get_model_str(struct hdhomerun_device_t *hd)
 		return NULL;
 	}
 	if (ret == 0) {
-		model_str = "hdhomerun_atsc";
+		hdhomerun_sprintf(hd->model, hd->model + sizeof(hd->model), "hdhomerun_atsc");
+		return hd->model;
 	}
 
-	strncpy(hd->model, model_str, sizeof(hd->model) - 1);
-	hd->model[sizeof(hd->model) - 1] = 0;
-
+	hdhomerun_sprintf(hd->model, hd->model + sizeof(hd->model), "%s", model_str);
 	return hd->model;
 }
 
 int hdhomerun_device_upgrade(struct hdhomerun_device_t *hd, FILE *upgrade_file)
 {
+	if (!hd->cs) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_upgrade: device not set\n");
+		return -1;
+	}
+
 	hdhomerun_control_set(hd->cs, "/tuner0/lockkey", "force", NULL, NULL);
 	hdhomerun_control_set(hd->cs, "/tuner0/channel", "none", NULL, NULL);
 
@@ -915,21 +1323,23 @@ void hdhomerun_device_debug_print_video_stats(struct hdhomerun_device_t *hd)
 		return;
 	}
 
-	char name[32];
-	sprintf(name, "/tuner%u/debug", hd->tuner);
+	if (hd->cs) {
+		char name[32];
+		hdhomerun_sprintf(name, name + sizeof(name), "/tuner%u/debug", hd->tuner);
 
-	char *debug_str;
-	char *error_str;
-	int ret = hdhomerun_control_get(hd->cs, name, &debug_str, &error_str);
-	if (ret < 0) {
-		hdhomerun_debug_printf(hd->dbg, "video dev: communication error getting debug stats\n");
-		return;
-	}
+		char *debug_str;
+		char *error_str;
+		int ret = hdhomerun_control_get(hd->cs, name, &debug_str, &error_str);
+		if (ret < 0) {
+			hdhomerun_debug_printf(hd->dbg, "video dev: communication error getting debug stats\n");
+			return;
+		}
 
-	if (error_str) {
-		hdhomerun_debug_printf(hd->dbg, "video dev: %s\n", error_str);
-	} else {
-		hdhomerun_debug_printf(hd->dbg, "video dev: %s\n", debug_str);
+		if (error_str) {
+			hdhomerun_debug_printf(hd->dbg, "video dev: %s\n", error_str);
+		} else {
+			hdhomerun_debug_printf(hd->dbg, "video dev: %s\n", debug_str);
+		}
 	}
 
 	if (hd->vs) {
@@ -939,5 +1349,11 @@ void hdhomerun_device_debug_print_video_stats(struct hdhomerun_device_t *hd)
 
 void hdhomerun_device_get_video_stats(struct hdhomerun_device_t *hd, struct hdhomerun_video_stats_t *stats)
 {
+	if (!hd->vs) {
+		hdhomerun_debug_printf(hd->dbg, "hdhomerun_device_stream_flush: video not initialized\n");
+		memset(stats, 0, sizeof(struct hdhomerun_video_stats_t));
+		return;
+	}
+
 	hdhomerun_video_get_stats(hd->vs, stats);
 }

--- a/third_party/SiliconDust/libhdhomerun/hdhomerun_device.h
+++ b/third_party/SiliconDust/libhdhomerun/hdhomerun_device.h
@@ -3,10 +3,10 @@
  *
  * Copyright © 2006-2008 Silicondust USA Inc. <www.silicondust.com>.
  *
- * This library is free software; you can redistribute it and/or 
+ * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
+ * version 2.1 of the License, or (at your option) any later version.
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -14,20 +14,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
- * 
- * As a special exception to the GNU Lesser General Public License,
- * you may link, statically or dynamically, an application with a
- * publicly distributed version of the Library to produce an
- * executable file containing portions of the Library, and
- * distribute that executable file under terms of your choice,
- * without any of the additional requirements listed in clause 4 of
- * the GNU Lesser General Public License.
- * 
- * By "a publicly distributed version of the Library", we mean
- * either the unmodified Library as distributed by Silicondust, or a
- * modified version of the Library that is distributed under the
- * conditions defined in the GNU Lesser General Public License.
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
 #ifdef __cplusplus
@@ -76,6 +64,7 @@ extern "C" {
  *     /tuner<tuner index>
  */
 extern LIBTYPE struct hdhomerun_device_t *hdhomerun_device_create(uint32_t device_id, uint32_t device_ip, unsigned int tuner, struct hdhomerun_debug_t *dbg);
+extern LIBTYPE struct hdhomerun_device_t *hdhomerun_device_create_multicast(uint32_t multicast_ip, uint16_t multicast_port, struct hdhomerun_debug_t *dbg);
 extern LIBTYPE struct hdhomerun_device_t *hdhomerun_device_create_from_str(const char *device_str, struct hdhomerun_debug_t *dbg);
 extern LIBTYPE void hdhomerun_device_destroy(struct hdhomerun_device_t *hd);
 
@@ -89,8 +78,9 @@ extern LIBTYPE uint32_t hdhomerun_device_get_device_id_requested(struct hdhomeru
 extern LIBTYPE uint32_t hdhomerun_device_get_device_ip_requested(struct hdhomerun_device_t *hd);
 extern LIBTYPE unsigned int hdhomerun_device_get_tuner(struct hdhomerun_device_t *hd);
 
-extern LIBTYPE void hdhomerun_device_set_device(struct hdhomerun_device_t *hd, uint32_t device_id, uint32_t device_ip);
-extern LIBTYPE void hdhomerun_device_set_tuner(struct hdhomerun_device_t *hd, unsigned int tuner);
+extern LIBTYPE int hdhomerun_device_set_device(struct hdhomerun_device_t *hd, uint32_t device_id, uint32_t device_ip);
+extern LIBTYPE int hdhomerun_device_set_multicast(struct hdhomerun_device_t *hd, uint32_t multicast_ip, uint16_t multicast_port);
+extern LIBTYPE int hdhomerun_device_set_tuner(struct hdhomerun_device_t *hd, unsigned int tuner);
 extern LIBTYPE int hdhomerun_device_set_tuner_from_str(struct hdhomerun_device_t *hd, const char *tuner_str);
 
 /*
@@ -114,22 +104,27 @@ extern LIBTYPE uint32_t hdhomerun_device_get_local_machine_addr(struct hdhomerun
  * Returns -1 if a communication error occurred.
  */
 extern LIBTYPE int hdhomerun_device_get_tuner_status(struct hdhomerun_device_t *hd, char **pstatus_str, struct hdhomerun_tuner_status_t *status);
+extern LIBTYPE int hdhomerun_device_get_tuner_vstatus(struct hdhomerun_device_t *hd, char **pvstatus_str, struct hdhomerun_tuner_vstatus_t *vstatus);
 extern LIBTYPE int hdhomerun_device_get_tuner_streaminfo(struct hdhomerun_device_t *hd, char **pstreaminfo);
 extern LIBTYPE int hdhomerun_device_get_tuner_channel(struct hdhomerun_device_t *hd, char **pchannel);
+extern LIBTYPE int hdhomerun_device_get_tuner_vchannel(struct hdhomerun_device_t *hd, char **pvchannel);
 extern LIBTYPE int hdhomerun_device_get_tuner_channelmap(struct hdhomerun_device_t *hd, char **pchannelmap);
 extern LIBTYPE int hdhomerun_device_get_tuner_filter(struct hdhomerun_device_t *hd, char **pfilter);
 extern LIBTYPE int hdhomerun_device_get_tuner_program(struct hdhomerun_device_t *hd, char **pprogram);
 extern LIBTYPE int hdhomerun_device_get_tuner_target(struct hdhomerun_device_t *hd, char **ptarget);
 extern LIBTYPE int hdhomerun_device_get_tuner_plotsample(struct hdhomerun_device_t *hd, struct hdhomerun_plotsample_t **psamples, size_t *pcount);
 extern LIBTYPE int hdhomerun_device_get_tuner_lockkey_owner(struct hdhomerun_device_t *hd, char **powner);
+extern LIBTYPE int hdhomerun_device_get_oob_status(struct hdhomerun_device_t *hd, char **pstatus_str, struct hdhomerun_tuner_status_t *status);
+extern LIBTYPE int hdhomerun_device_get_oob_plotsample(struct hdhomerun_device_t *hd, struct hdhomerun_plotsample_t **psamples, size_t *pcount);
 extern LIBTYPE int hdhomerun_device_get_ir_target(struct hdhomerun_device_t *hd, char **ptarget);
-extern LIBTYPE int hdhomerun_device_get_lineup_location(struct hdhomerun_device_t *hd, char **plocation);
 extern LIBTYPE int hdhomerun_device_get_version(struct hdhomerun_device_t *hd, char **pversion_str, uint32_t *pversion_num);
+extern LIBTYPE int hdhomerun_device_get_supported(struct hdhomerun_device_t *hd, char *prefix, char **pstr);
 
 extern LIBTYPE uint32_t hdhomerun_device_get_tuner_status_ss_color(struct hdhomerun_tuner_status_t *status);
 extern LIBTYPE uint32_t hdhomerun_device_get_tuner_status_snq_color(struct hdhomerun_tuner_status_t *status);
 extern LIBTYPE uint32_t hdhomerun_device_get_tuner_status_seq_color(struct hdhomerun_tuner_status_t *status);
 
+extern LIBTYPE const char *hdhomerun_device_get_hw_model_str(struct hdhomerun_device_t *hd);
 extern LIBTYPE const char *hdhomerun_device_get_model_str(struct hdhomerun_device_t *hd);
 
 /*
@@ -142,15 +137,14 @@ extern LIBTYPE const char *hdhomerun_device_get_model_str(struct hdhomerun_devic
  * Returns -1 if a communication error occurred.
  */
 extern LIBTYPE int hdhomerun_device_set_tuner_channel(struct hdhomerun_device_t *hd, const char *channel);
+extern LIBTYPE int hdhomerun_device_set_tuner_vchannel(struct hdhomerun_device_t *hd, const char *vchannel);
 extern LIBTYPE int hdhomerun_device_set_tuner_channelmap(struct hdhomerun_device_t *hd, const char *channelmap);
 extern LIBTYPE int hdhomerun_device_set_tuner_filter(struct hdhomerun_device_t *hd, const char *filter);
 extern LIBTYPE int hdhomerun_device_set_tuner_filter_by_array(struct hdhomerun_device_t *hd, unsigned char filter_array[0x2000]);
 extern LIBTYPE int hdhomerun_device_set_tuner_program(struct hdhomerun_device_t *hd, const char *program);
 extern LIBTYPE int hdhomerun_device_set_tuner_target(struct hdhomerun_device_t *hd, const char *target);
-extern LIBTYPE int hdhomerun_device_set_tuner_target_to_local_protocol(struct hdhomerun_device_t *hd, const char *protocol);
-extern LIBTYPE int hdhomerun_device_set_tuner_target_to_local(struct hdhomerun_device_t *hd);
 extern LIBTYPE int hdhomerun_device_set_ir_target(struct hdhomerun_device_t *hd, const char *target);
-extern LIBTYPE int hdhomerun_device_set_lineup_location(struct hdhomerun_device_t *hd, const char *location);
+extern LIBTYPE int hdhomerun_device_set_sys_dvbc_modulation(struct hdhomerun_device_t *hd, const char *modulation_list);
 
 /*
  * Get/set a named control variable on the device.
@@ -218,12 +212,11 @@ extern LIBTYPE int hdhomerun_device_wait_for_lock(struct hdhomerun_device_t *hd,
  * Returns -1 if a communication error occurs.
  *
  * The hdhomerun_device_stream_recv function should be called periodically to receive the stream data.
- * The buffer can losslessly store 1 second of data, however a more typical call rate would be every 64ms.
+ * The buffer can losslessly store 1 second of data, however a more typical call rate would be every 15ms.
  *
  * The hdhomerun_device_stream_stop function tells the device to stop streaming data.
  */
 extern LIBTYPE int hdhomerun_device_stream_start(struct hdhomerun_device_t *hd);
-extern LIBTYPE int hdhomerun_device_stream_refresh_target(struct hdhomerun_device_t *hd);
 extern LIBTYPE uint8_t *hdhomerun_device_stream_recv(struct hdhomerun_device_t *hd, size_t max_size, size_t *pactual_size);
 extern LIBTYPE void hdhomerun_device_stream_flush(struct hdhomerun_device_t *hd);
 extern LIBTYPE void hdhomerun_device_stream_stop(struct hdhomerun_device_t *hd);
@@ -235,17 +228,6 @@ extern LIBTYPE int hdhomerun_device_channelscan_init(struct hdhomerun_device_t *
 extern LIBTYPE int hdhomerun_device_channelscan_advance(struct hdhomerun_device_t *hd, struct hdhomerun_channelscan_result_t *result);
 extern LIBTYPE int hdhomerun_device_channelscan_detect(struct hdhomerun_device_t *hd, struct hdhomerun_channelscan_result_t *result);
 extern LIBTYPE uint8_t hdhomerun_device_channelscan_get_progress(struct hdhomerun_device_t *hd);
-
-/*
- * Check that the device is running the recommended firmware.
- *
- * uint32_t features: Reserved for future use. Set to zero.
- *
- * Returns 1 if the firmware meets the minimum requriements for all operations.
- * Returns 0 if th firmware does not meet the minimum requriements for all operations.
- * Returns -1 if an error occurs.
- */
-extern LIBTYPE int hdhomerun_device_firmware_version_check(struct hdhomerun_device_t *hd, uint32_t features);
 
 /*
  * Upload new firmware to the device.

--- a/third_party/SiliconDust/libhdhomerun/hdhomerun_device_selector.c
+++ b/third_party/SiliconDust/libhdhomerun/hdhomerun_device_selector.c
@@ -1,12 +1,12 @@
 /*
  * hdhomerun_device_selector.c
  *
- * Copyright © 2009 Silicondust USA Inc. <www.silicondust.com>.
+ * Copyright © 2009-2010 Silicondust USA Inc. <www.silicondust.com>.
  *
- * This library is free software; you can redistribute it and/or 
+ * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
+ * version 2.1 of the License, or (at your option) any later version.
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -14,20 +14,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
- * 
- * As a special exception to the GNU Lesser General Public License,
- * you may link, statically or dynamically, an application with a
- * publicly distributed version of the Library to produce an
- * executable file containing portions of the Library, and
- * distribute that executable file under terms of your choice,
- * without any of the additional requirements listed in clause 4 of
- * the GNU Lesser General Public License.
- * 
- * By "a publicly distributed version of the Library", we mean
- * either the unmodified Library as distributed by Silicondust, or a
- * modified version of the Library that is distributed under the
- * conditions defined in the GNU Lesser General Public License.
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
 #include "hdhomerun.h"
@@ -66,6 +54,11 @@ void hdhomerun_device_selector_destroy(struct hdhomerun_device_selector_t *hds, 
 	}
 
 	free(hds);
+}
+
+LIBTYPE int hdhomerun_device_selector_get_device_count(struct hdhomerun_device_selector_t *hds)
+{
+	return (int)hds->hd_count;
 }
 
 void hdhomerun_device_selector_add_device(struct hdhomerun_device_selector_t *hds, struct hdhomerun_device_t *hd)
@@ -129,55 +122,173 @@ struct hdhomerun_device_t *hdhomerun_device_selector_find_device(struct hdhomeru
 	return NULL;
 }
 
-void hdhomerun_device_selector_load_from_file(struct hdhomerun_device_selector_t *hds, char *filename)
+static int hdhomerun_device_selector_load_from_str_discover(struct hdhomerun_device_selector_t *hds, uint32_t target_ip, uint32_t device_id)
+{
+	struct hdhomerun_discover_device_t result_list[64];
+	int discover_count = hdhomerun_discover_find_devices_custom(target_ip, HDHOMERUN_DEVICE_TYPE_TUNER, device_id, result_list, 64);
+
+	int count = 0;
+	int result_index;
+	struct hdhomerun_discover_device_t *result = result_list;
+	for (result_index = 0; result_index < discover_count; result_index++) {
+		unsigned int tuner_index;
+		for (tuner_index = 0; tuner_index < result->tuner_count; tuner_index++) {
+			struct hdhomerun_device_t *hd = hdhomerun_device_create(result->device_id, result->ip_addr, tuner_index, hds->dbg);
+			if (!hd) {
+				continue;
+			}
+
+			hdhomerun_device_selector_add_device(hds, hd);
+			count++;
+		}
+
+		result++;
+	}
+
+	return count;
+}
+
+int hdhomerun_device_selector_load_from_str(struct hdhomerun_device_selector_t *hds, char *device_str)
+{
+	/*
+	 * IP address based device_str.
+	 */
+	unsigned int a[4];
+	if (sscanf(device_str, "%u.%u.%u.%u", &a[0], &a[1], &a[2], &a[3]) == 4) {
+		uint32_t ip_addr = (uint32_t)((a[0] << 24) | (a[1] << 16) | (a[2] << 8) | (a[3] << 0));
+
+		/*
+		 * Multicast IP address.
+		 */
+		unsigned int port;
+		if (sscanf(device_str, "%u.%u.%u.%u:%u", &a[0], &a[1], &a[2], &a[3], &port) == 5) {
+			struct hdhomerun_device_t *hd = hdhomerun_device_create_multicast(ip_addr, port, hds->dbg);
+			if (!hd) {
+				return 0;
+			}
+
+			hdhomerun_device_selector_add_device(hds, hd);
+			return 1;
+		}
+
+		/*
+		 * IP address + tuner number.
+		 */
+		unsigned int tuner;
+		if (sscanf(device_str, "%u.%u.%u.%u-%u", &a[0], &a[1], &a[2], &a[3], &tuner) == 5) {
+			struct hdhomerun_device_t *hd = hdhomerun_device_create(HDHOMERUN_DEVICE_ID_WILDCARD, ip_addr, tuner, hds->dbg);
+			if (!hd) {
+				return 0;
+			}
+
+			hdhomerun_device_selector_add_device(hds, hd);
+			return 1;
+		}
+
+		/*
+		 * IP address only - discover and add tuners.
+		 */
+		return hdhomerun_device_selector_load_from_str_discover(hds, ip_addr, HDHOMERUN_DEVICE_ID_WILDCARD);
+	}
+
+	/*
+	 * Device ID based device_str.
+	 */
+	char *end;
+	uint32_t device_id = (uint32_t)strtoul(device_str, &end, 16);
+	if ((end == device_str + 8) && hdhomerun_discover_validate_device_id(device_id)) {
+		/*
+		 * IP address + tuner number.
+		 */
+		if (*end == '-') {
+			unsigned int tuner = (unsigned int)strtoul(end + 1, NULL, 10);
+			struct hdhomerun_device_t *hd = hdhomerun_device_create(device_id, 0, tuner, hds->dbg);
+			if (!hd) {
+				return 0;
+			}
+
+			hdhomerun_device_selector_add_device(hds, hd);
+			return 1;
+		}
+
+		/*
+		 * Device ID only - discover and add tuners.
+		 */
+		return hdhomerun_device_selector_load_from_str_discover(hds, 0, device_id);
+	}
+
+	/*
+	* DNS based device_str.
+	*/
+	struct addrinfo hints;
+	memset(&hints, 0, sizeof(hints));
+	hints.ai_family = AF_INET;
+	hints.ai_socktype = SOCK_STREAM;
+	hints.ai_protocol = IPPROTO_TCP;
+
+	struct addrinfo *sock_info;
+	if (getaddrinfo(device_str, "65001", &hints, &sock_info) != 0) {
+		return 0;
+	}
+
+	struct sockaddr_in *sock_addr = (struct sockaddr_in *)sock_info->ai_addr;
+	uint32_t ip_addr = (uint32_t)ntohl(sock_addr->sin_addr.s_addr);
+	freeaddrinfo(sock_info);
+
+	if (ip_addr == 0) {
+		return 0;
+	}
+
+	return hdhomerun_device_selector_load_from_str_discover(hds, ip_addr, HDHOMERUN_DEVICE_ID_WILDCARD);
+}
+
+int hdhomerun_device_selector_load_from_file(struct hdhomerun_device_selector_t *hds, char *filename)
 {
 	FILE *fp = fopen(filename, "r");
 	if (!fp) {
-		return;
+		return 0;
 	}
 
+	int count = 0;
 	while(1) {
-		char device_name[32];
-		if (!fgets(device_name, sizeof(device_name), fp)) {
+		char device_str[32];
+		if (!fgets(device_str, sizeof(device_str), fp)) {
 			break;
 		}
 
-		struct hdhomerun_device_t *hd = hdhomerun_device_create_from_str(device_name, hds->dbg);
-		if (!hd) {
-			continue;
-		}
-
-		hdhomerun_device_selector_add_device(hds, hd);
+		count += hdhomerun_device_selector_load_from_str(hds, device_str);
 	}
 
 	fclose(fp);
+	return count;
 }
 
 #if defined(__WINDOWS__)
-void hdhomerun_device_selector_load_from_windows_registry(struct hdhomerun_device_selector_t *hds, wchar_t *wsource)
+int hdhomerun_device_selector_load_from_windows_registry(struct hdhomerun_device_selector_t *hds, wchar_t *wsource)
 {
 	HKEY tuners_key;
 	LONG ret = RegOpenKeyEx(HKEY_LOCAL_MACHINE, L"SOFTWARE\\Silicondust\\HDHomeRun\\Tuners", 0, KEY_QUERY_VALUE | KEY_ENUMERATE_SUB_KEYS, &tuners_key);
 	if (ret != ERROR_SUCCESS) {
-		hdhomerun_debug_printf(hds->dbg, "hdhomerun_device_selector_load_from_windows_registry: failed to open tuners registry key (%ld)\n", ret);
-		return;
+		hdhomerun_debug_printf(hds->dbg, "hdhomerun_device_selector_load_from_windows_registry: failed to open tuners registry key (%ld)\n", (long)ret);
+		return 0;
 	}
 
+	int count = 0;
 	DWORD index = 0;
 	while (1) {
 		/* Next tuner device. */
-		wchar_t wdevice_name[32];
-		DWORD size = sizeof(wdevice_name);
-		ret = RegEnumKeyEx(tuners_key, index++, wdevice_name, &size, NULL, NULL, NULL, NULL);
+		wchar_t wdevice_str[32];
+		DWORD size = sizeof(wdevice_str);
+		ret = RegEnumKeyEx(tuners_key, index++, wdevice_str, &size, NULL, NULL, NULL, NULL);
 		if (ret != ERROR_SUCCESS) {
 			break;
 		}
 
 		/* Check device configuation. */
 		HKEY device_key;
-		ret = RegOpenKeyEx(tuners_key, wdevice_name, 0, KEY_QUERY_VALUE, &device_key);
+		ret = RegOpenKeyEx(tuners_key, wdevice_str, 0, KEY_QUERY_VALUE, &device_key);
 		if (ret != ERROR_SUCCESS) {
-			hdhomerun_debug_printf(hds->dbg, "hdhomerun_device_selector_load_from_windows_registry: failed to open registry key for %S (%ld)\n", wdevice_name, ret);
+			hdhomerun_debug_printf(hds->dbg, "hdhomerun_device_selector_load_from_windows_registry: failed to open registry key for %S (%ld)\n", wdevice_str, (long)ret);
 			continue;
 		}
 
@@ -194,19 +305,13 @@ void hdhomerun_device_selector_load_from_windows_registry(struct hdhomerun_devic
 		}
 
 		/* Create and add device. */
-		char device_name[32];
-		sprintf(device_name, "%S", wdevice_name);
-
-		struct hdhomerun_device_t *hd = hdhomerun_device_create_from_str(device_name, hds->dbg);
-		if (!hd) {
-			hdhomerun_debug_printf(hds->dbg, "hdhomerun_device_selector_load_from_windows_registry: invalid device name '%s' / failed to create device object\n", device_name);
-			continue;
-		}
-
-		hdhomerun_device_selector_add_device(hds, hd);
+		char device_str[32];
+		hdhomerun_sprintf(device_str, device_str + sizeof(device_str), "%S", wdevice_str);
+		count += hdhomerun_device_selector_load_from_str(hds, device_str);
 	}
 
 	RegCloseKey(tuners_key);
+	return count;
 }
 #endif
 
@@ -242,19 +347,20 @@ static bool_t hdhomerun_device_selector_choose_test(struct hdhomerun_device_sele
 		return FALSE;
 	}
 
-	char *ptr = strstr(target, "//");
-	if (ptr) {
-		target = ptr + 2;
-	}
-	ptr = strchr(target, ' ');
-	if (ptr) {
-		*ptr = 0;
+	if (strcmp(target, "none") == 0) {
+		hdhomerun_debug_printf(hds->dbg, "hdhomerun_device_selector_choose_test: device %s in use, no target set\n", name);
+		return FALSE;
 	}
 
-	unsigned long a[4];
-	unsigned long target_port;
-	if (sscanf(target, "%lu.%lu.%lu.%lu:%lu", &a[0], &a[1], &a[2], &a[3], &target_port) != 5) {
-		hdhomerun_debug_printf(hds->dbg, "hdhomerun_device_selector_choose_test: device %s in use, no target set (%s)\n", name, target);
+	if ((strncmp(target, "udp://", 6) != 0) && (strncmp(target, "rtp://", 6) != 0)) {
+		hdhomerun_debug_printf(hds->dbg, "hdhomerun_device_selector_choose_test: device %s in use by %s\n", name, target);
+		return FALSE;
+	}
+
+	unsigned int a[4];
+	unsigned int target_port;
+	if (sscanf(target + 6, "%u.%u.%u.%u:%u", &a[0], &a[1], &a[2], &a[3], &target_port) != 5) {
+		hdhomerun_debug_printf(hds->dbg, "hdhomerun_device_selector_choose_test: device %s in use, unexpected target set (%s)\n", name, target);
 		return FALSE;
 	}
 
@@ -268,21 +374,16 @@ static bool_t hdhomerun_device_selector_choose_test(struct hdhomerun_device_sele
 	/*
 	 * Test local port.
 	 */
-	int test_sock = (int)socket(AF_INET, SOCK_DGRAM, 0);
-	if (test_sock == -1) {
+	hdhomerun_sock_t test_sock = hdhomerun_sock_create_udp();
+	if (test_sock == HDHOMERUN_SOCK_INVALID) {
 		hdhomerun_debug_printf(hds->dbg, "hdhomerun_device_selector_choose_test: device %s in use, failed to create test sock\n", name);
 		return FALSE;
 	}
 
-	struct sockaddr_in sock_addr;
-	memset(&sock_addr, 0, sizeof(sock_addr));
-	sock_addr.sin_family = AF_INET;
-	sock_addr.sin_addr.s_addr = htonl(INADDR_ANY);
-	sock_addr.sin_port = htons((uint16_t)target_port);
-	ret = bind(test_sock, (struct sockaddr *)&sock_addr, sizeof(sock_addr));
-	close(test_sock);
+	bool_t inuse = (hdhomerun_sock_bind(test_sock, INADDR_ANY, (uint16_t)target_port, FALSE) == FALSE);
+	hdhomerun_sock_destroy(test_sock);
 
-	if (ret != 0) {
+	if (inuse) {
 		hdhomerun_debug_printf(hds->dbg, "hdhomerun_device_selector_choose_test: device %s in use by local machine\n", name);
 		return FALSE;
 	}

--- a/third_party/SiliconDust/libhdhomerun/hdhomerun_device_selector.h
+++ b/third_party/SiliconDust/libhdhomerun/hdhomerun_device_selector.h
@@ -3,10 +3,10 @@
  *
  * Copyright © 2009 Silicondust USA Inc. <www.silicondust.com>.
  *
- * This library is free software; you can redistribute it and/or 
+ * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
+ * version 2.1 of the License, or (at your option) any later version.
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -14,20 +14,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
- * 
- * As a special exception to the GNU Lesser General Public License,
- * you may link, statically or dynamically, an application with a
- * publicly distributed version of the Library to produce an
- * executable file containing portions of the Library, and
- * distribute that executable file under terms of your choice,
- * without any of the additional requirements listed in clause 4 of
- * the GNU Lesser General Public License.
- * 
- * By "a publicly distributed version of the Library", we mean
- * either the unmodified Library as distributed by Silicondust, or a
- * modified version of the Library that is distributed under the
- * conditions defined in the GNU Lesser General Public License.
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
 #ifdef __cplusplus
@@ -43,11 +31,18 @@ extern LIBTYPE struct hdhomerun_device_selector_t *hdhomerun_device_selector_cre
 extern LIBTYPE void hdhomerun_device_selector_destroy(struct hdhomerun_device_selector_t *hds, bool_t destroy_devices);
 
 /*
- * Populate device selector with devices from given source.
+ * Get the number of devices in the list.
  */
-extern LIBTYPE void hdhomerun_device_selector_load_from_file(struct hdhomerun_device_selector_t *hds, char *filename);
+extern LIBTYPE int hdhomerun_device_selector_get_device_count(struct hdhomerun_device_selector_t *hds);
+
+/*
+ * Populate device selector with devices from given source.
+ * Returns the number of devices populated.
+ */
+extern LIBTYPE int hdhomerun_device_selector_load_from_str(struct hdhomerun_device_selector_t *hds, char *device_str);
+extern LIBTYPE int hdhomerun_device_selector_load_from_file(struct hdhomerun_device_selector_t *hds, char *filename);
 #if defined(__WINDOWS__)
-extern LIBTYPE void hdhomerun_device_selector_load_from_windows_registry(struct hdhomerun_device_selector_t *hds, wchar_t *wsource);
+extern LIBTYPE int hdhomerun_device_selector_load_from_windows_registry(struct hdhomerun_device_selector_t *hds, wchar_t *wsource);
 #endif
 
 /*

--- a/third_party/SiliconDust/libhdhomerun/hdhomerun_discover.h
+++ b/third_party/SiliconDust/libhdhomerun/hdhomerun_discover.h
@@ -3,10 +3,10 @@
  *
  * Copyright © 2006-2007 Silicondust USA Inc. <www.silicondust.com>.
  *
- * This library is free software; you can redistribute it and/or 
+ * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
+ * version 2.1 of the License, or (at your option) any later version.
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -14,20 +14,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
- * 
- * As a special exception to the GNU Lesser General Public License,
- * you may link, statically or dynamically, an application with a
- * publicly distributed version of the Library to produce an
- * executable file containing portions of the Library, and
- * distribute that executable file under terms of your choice,
- * without any of the additional requirements listed in clause 4 of
- * the GNU Lesser General Public License.
- * 
- * By "a publicly distributed version of the Library", we mean
- * either the unmodified Library as distributed by Silicondust, or a
- * modified version of the Library that is distributed under the
- * conditions defined in the GNU Lesser General Public License.
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 #ifdef __cplusplus
 extern "C" {
@@ -37,6 +25,7 @@ struct hdhomerun_discover_device_t {
 	uint32_t ip_addr;
 	uint32_t device_type;
 	uint32_t device_id;
+	uint8_t tuner_count;
 };
 
 /*
@@ -44,14 +33,23 @@ struct hdhomerun_discover_device_t {
  *
  * The device information is stored in caller-supplied array of hdhomerun_discover_device_t vars.
  * Multiple attempts are made to find devices.
- * Execution time is 1 second.
+ * Execution time is typically 400ms if max_count is not reached.
  *
- * Set target_ip to zero to auto-detect IP address.
+ * Set target_ip to zero to auto-detect the IP address.
+ * Set device_type to HDHOMERUN_DEVICE_TYPE_TUNER to detect HDHomeRun tuner devices.
+ * Set device_id to HDHOMERUN_DEVICE_ID_WILDCARD to detect all device ids.
  *
  * Returns the number of devices found.
  * Retruns -1 on error.
  */
 extern LIBTYPE int hdhomerun_discover_find_devices_custom(uint32_t target_ip, uint32_t device_type, uint32_t device_id, struct hdhomerun_discover_device_t result_list[], int max_count);
+
+/*
+ * Optional: persistent discover instance available for discover polling use.
+ */
+extern LIBTYPE struct hdhomerun_discover_t *hdhomerun_discover_create(struct hdhomerun_debug_t *dbg);
+extern LIBTYPE void hdhomerun_discover_destroy(struct hdhomerun_discover_t *ds);
+extern LIBTYPE int hdhomerun_discover_find_devices(struct hdhomerun_discover_t *ds, uint32_t target_ip, uint32_t device_type, uint32_t device_id, struct hdhomerun_discover_device_t result_list[], int max_count);
 
 /*
  * Verify that the device ID given is valid.
@@ -63,6 +61,14 @@ extern LIBTYPE int hdhomerun_discover_find_devices_custom(uint32_t target_ip, ui
  * Returns FALSE if not valid.
  */
 extern LIBTYPE bool_t hdhomerun_discover_validate_device_id(uint32_t device_id);
+
+/*
+ * Detect if an IP address is multicast.
+ *
+ * Returns TRUE if multicast.
+ * Returns FALSE if zero, unicast, expermental, or broadcast.
+ */
+extern LIBTYPE bool_t hdhomerun_discover_is_ip_multicast(uint32_t ip_addr);
 
 #ifdef __cplusplus
 }

--- a/third_party/SiliconDust/libhdhomerun/hdhomerun_os.h
+++ b/third_party/SiliconDust/libhdhomerun/hdhomerun_os.h
@@ -3,10 +3,10 @@
  *
  * Copyright © 2006-2008 Silicondust USA Inc. <www.silicondust.com>.
  *
- * This library is free software; you can redistribute it and/or 
+ * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
+ * version 2.1 of the License, or (at your option) any later version.
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -14,20 +14,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
- * 
- * As a special exception to the GNU Lesser General Public License,
- * you may link, statically or dynamically, an application with a
- * publicly distributed version of the Library to produce an
- * executable file containing portions of the Library, and
- * distribute that executable file under terms of your choice,
- * without any of the additional requirements listed in clause 4 of
- * the GNU Lesser General Public License.
- * 
- * By "a publicly distributed version of the Library", we mean
- * either the unmodified Library as distributed by Silicondust, or a
- * modified version of the Library that is distributed under the
- * conditions defined in the GNU Lesser General Public License.
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
 #if defined(_WIN32) || defined(_WIN64)

--- a/third_party/SiliconDust/libhdhomerun/hdhomerun_os_posix.c
+++ b/third_party/SiliconDust/libhdhomerun/hdhomerun_os_posix.c
@@ -1,0 +1,128 @@
+/*
+ * hdhomerun_os_posix.c
+ *
+ * Copyright © 2006-2010 Silicondust USA Inc. <www.silicondust.com>.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "hdhomerun_os.h"
+
+#if defined(__APPLE__)
+#include <mach/clock.h>
+#include <mach/mach.h>
+#endif
+
+static pthread_once_t random_get32_once = PTHREAD_ONCE_INIT;
+static FILE *random_get32_fp = NULL;
+
+static void random_get32_init(void)
+{
+	random_get32_fp = fopen("/dev/urandom", "rb");
+}
+
+uint32_t random_get32(void)
+{
+	pthread_once(&random_get32_once, random_get32_init);
+
+	if (!random_get32_fp) {
+		return (uint32_t)getcurrenttime();
+	}
+
+	uint32_t Result;
+	if (fread(&Result, 4, 1, random_get32_fp) != 1) {
+		return (uint32_t)getcurrenttime();
+	}
+
+	return Result;
+}
+
+uint64_t getcurrenttime(void)
+{
+#if defined(CLOCK_MONOTONIC)
+	struct timespec t;
+	clock_gettime(CLOCK_MONOTONIC, &t);
+	return ((uint64_t)t.tv_sec * 1000) + (t.tv_nsec / 1000000);
+#elif defined(__APPLE__)
+	clock_serv_t clock_serv;
+	host_get_clock_service(mach_host_self(), SYSTEM_CLOCK, &clock_serv);
+
+	struct mach_timespec t;
+	clock_get_time(clock_serv, &t);
+
+	mach_port_deallocate(mach_task_self(), clock_serv);
+	return ((uint64_t)t.tv_sec * 1000) + (t.tv_nsec / 1000000);
+#else
+#error no clock source for getcurrenttime()
+#endif
+}
+
+void msleep_approx(uint64_t ms)
+{
+	unsigned int delay_s = ms / 1000;
+	if (delay_s > 0) {
+		sleep(delay_s);
+		ms -= delay_s * 1000;
+	}
+
+	unsigned int delay_us = ms * 1000;
+	if (delay_us > 0) {
+		usleep(delay_us);
+	}
+}
+
+void msleep_minimum(uint64_t ms)
+{
+	uint64_t stop_time = getcurrenttime() + ms;
+
+	while (1) {
+		uint64_t current_time = getcurrenttime();
+		if (current_time >= stop_time) {
+			return;
+		}
+
+		msleep_approx(stop_time - current_time);
+	}
+}
+
+bool_t hdhomerun_vsprintf(char *buffer, char *end, const char *fmt, va_list ap)
+{
+	if (buffer >= end) {
+		return FALSE;
+	}
+
+	int length = vsnprintf(buffer, end - buffer - 1, fmt, ap);
+	if (length < 0) {
+		*buffer = 0;
+		return FALSE;
+	}
+
+	if (buffer + length + 1 > end) {
+		*(end - 1) = 0;
+		return FALSE;
+
+	}
+
+	return TRUE;
+}
+
+bool_t hdhomerun_sprintf(char *buffer, char *end, const char *fmt, ...)
+{
+	va_list ap;
+	va_start(ap, fmt);
+	bool_t result = hdhomerun_vsprintf(buffer, end, fmt, ap);
+	va_end(ap);
+	return result;
+}

--- a/third_party/SiliconDust/libhdhomerun/hdhomerun_os_windows.c
+++ b/third_party/SiliconDust/libhdhomerun/hdhomerun_os_windows.c
@@ -1,0 +1,152 @@
+/*
+ * hdhomerun_os_windows.c
+ *
+ * Copyright © 2006-2010 Silicondust USA Inc. <www.silicondust.com>.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "hdhomerun_os.h"
+
+static DWORD random_get32_context_tls = TlsAlloc();
+
+uint32_t random_get32(void)
+{
+	HCRYPTPROV *phProv = (HCRYPTPROV *)TlsGetValue(random_get32_context_tls);
+	if (!phProv) {
+		phProv = (HCRYPTPROV *)calloc(1, sizeof(HCRYPTPROV));
+		CryptAcquireContext(phProv, 0, 0, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT);
+		TlsSetValue(random_get32_context_tls, phProv);
+	}
+
+	uint32_t Result;
+	if (!CryptGenRandom(*phProv, sizeof(Result), (BYTE *)&Result)) {
+		return (uint32_t)getcurrenttime();
+	}
+
+	return Result;
+}
+
+uint64_t getcurrenttime(void)
+{
+	return GetTickCount64();
+}
+
+void msleep_approx(uint64_t ms)
+{
+	Sleep((DWORD)ms);
+}
+
+void msleep_minimum(uint64_t ms)
+{
+	uint64_t stop_time = getcurrenttime() + ms;
+
+	while (1) {
+		uint64_t current_time = getcurrenttime();
+		if (current_time >= stop_time) {
+			return;
+		}
+
+		msleep_approx(stop_time - current_time);
+	}
+}
+
+int pthread_create(pthread_t *tid, void *attr, LPTHREAD_START_ROUTINE start, void *arg)
+{
+	*tid = CreateThread(NULL, 0, start, arg, 0, NULL);
+	if (!*tid) {
+		return (int)GetLastError();
+	}
+	return 0;
+}
+
+int pthread_join(pthread_t tid, void **value_ptr)
+{
+	while (1) {
+		DWORD ExitCode = 0;
+		if (!GetExitCodeThread(tid, &ExitCode)) {
+			return (int)GetLastError();
+		}
+		if (ExitCode != STILL_ACTIVE) {
+			return 0;
+		}
+	}
+}
+
+void pthread_mutex_init(pthread_mutex_t *mutex, void *attr)
+{
+	*mutex = CreateMutex(NULL, FALSE, NULL);
+}
+
+void pthread_mutex_lock(pthread_mutex_t *mutex)
+{
+	WaitForSingleObject(*mutex, INFINITE);
+}
+
+void pthread_mutex_unlock(pthread_mutex_t *mutex)
+{
+	ReleaseMutex(*mutex);
+}
+
+bool_t hdhomerun_vsprintf(char *buffer, char *end, const char *fmt, va_list ap)
+{
+	if (buffer >= end) {
+		return FALSE;
+	}
+
+	int length = _vsnprintf(buffer, end - buffer - 1, fmt, ap);
+	if (length < 0) {
+		*buffer = 0;
+		return FALSE;
+	}
+
+	if (buffer + length + 1 > end) {
+		*(end - 1) = 0;
+		return FALSE;
+
+	}
+
+	return TRUE;
+}
+
+bool_t hdhomerun_sprintf(char *buffer, char *end, const char *fmt, ...)
+{
+	va_list ap;
+	va_start(ap, fmt);
+	bool_t result = hdhomerun_vsprintf(buffer, end, fmt, ap);
+	va_end(ap);
+	return result;
+}
+
+/*
+ * The console output format should be set to UTF-8, however in XP and Vista this breaks batch file processing.
+ * Attempting to restore on exit fails to restore if the program is terminated by the user.
+ * Solution - set the output format each printf.
+ */
+void console_vprintf(const char *fmt, va_list ap)
+{
+	UINT cp = GetConsoleOutputCP();
+	SetConsoleOutputCP(CP_UTF8);
+	vprintf(fmt, ap);
+	SetConsoleOutputCP(cp);
+}
+
+void console_printf(const char *fmt, ...)
+{
+	va_list ap;
+	va_start(ap, fmt);
+	console_vprintf(fmt, ap);
+	va_end(ap);
+}

--- a/third_party/SiliconDust/libhdhomerun/hdhomerun_os_windows.h
+++ b/third_party/SiliconDust/libhdhomerun/hdhomerun_os_windows.h
@@ -1,12 +1,12 @@
 /*
  * hdhomerun_os_windows.h
  *
- * Copyright © 2006-2008 Silicondust USA Inc. <www.silicondust.com>.
+ * Copyright © 2006-2010 Silicondust USA Inc. <www.silicondust.com>.
  *
- * This library is free software; you can redistribute it and/or 
+ * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
+ * version 2.1 of the License, or (at your option) any later version.
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -14,20 +14,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
- * 
- * As a special exception to the GNU Lesser General Public License,
- * you may link, statically or dynamically, an application with a
- * publicly distributed version of the Library to produce an
- * executable file containing portions of the Library, and
- * distribute that executable file under terms of your choice,
- * without any of the additional requirements listed in clause 4 of
- * the GNU Lesser General Public License.
- * 
- * By "a publicly distributed version of the Library", we mean
- * either the unmodified Library as distributed by Silicondust, or a
- * modified version of the Library that is distributed under the
- * conditions defined in the GNU Lesser General Public License.
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
 #define _WINSOCKAPI_
@@ -61,111 +49,47 @@ typedef unsigned __int8 uint8_t;
 typedef unsigned __int16 uint16_t;
 typedef unsigned __int32 uint32_t;
 typedef unsigned __int64 uint64_t;
+typedef void (*sig_t)(int);
 typedef HANDLE pthread_t;
 typedef HANDLE pthread_mutex_t;
 
-#define socklen_t int
-#define close closesocket
-#define sock_getlasterror WSAGetLastError()
-#define sock_getlasterror_socktimeout (WSAGetLastError() == WSAETIMEDOUT)
+#if !defined(va_copy)
 #define va_copy(x, y) x = y
+#endif
+
 #define atoll _atoi64
 #define strdup _strdup
 #define strcasecmp _stricmp
-#define snprintf _snprintf
 #define fseeko _fseeki64
 #define ftello _ftelli64
 #define THREAD_FUNC_PREFIX DWORD WINAPI
-#define SIGPIPE SIGABRT
 
-static inline uint64_t getcurrenttime(void)
-{
-	struct timeb tb;
-	ftime(&tb);
-	return ((uint64_t)tb.time * 1000) + tb.millitm;
-}
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-static inline int msleep(unsigned int ms)
-{
-	uint64_t stop_time = getcurrenttime() + ms;
+extern LIBTYPE uint32_t random_get32(void);
+extern LIBTYPE uint64_t getcurrenttime(void);
+extern LIBTYPE void msleep_approx(uint64_t ms);
+extern LIBTYPE void msleep_minimum(uint64_t ms);
 
-	while (1) {
-		uint64_t current_time = getcurrenttime();
-		if (current_time >= stop_time) {
-			return 0;
-		}
+extern LIBTYPE int pthread_create(pthread_t *tid, void *attr, LPTHREAD_START_ROUTINE start, void *arg);
+extern LIBTYPE int pthread_join(pthread_t tid, void **value_ptr);
+extern LIBTYPE void pthread_mutex_init(pthread_mutex_t *mutex, void *attr);
+extern LIBTYPE void pthread_mutex_lock(pthread_mutex_t *mutex);
+extern LIBTYPE void pthread_mutex_unlock(pthread_mutex_t *mutex);
 
-		uint64_t delay_ms = stop_time - current_time;
-		Sleep((DWORD)delay_ms);
-	}
-}
-
-static inline int sleep(unsigned int sec)
-{
-	msleep(sec * 1000);
-	return 0;
-}
-
-static inline int setsocktimeout(int s, int level, int optname, uint64_t timeout)
-{
-	int t = (int)timeout;
-	return setsockopt(s, level, optname, (char *)&t, sizeof(t));
-}
-
-static inline int pthread_create(pthread_t *tid, void *attr, LPTHREAD_START_ROUTINE start, void *arg)
-{
-	*tid = CreateThread(NULL, 0, start, arg, 0, NULL);
-	if (!*tid) {
-		return (int)GetLastError();
-	}
-	return 0;
-}
-
-static inline int pthread_join(pthread_t tid, void **value_ptr)
-{
-	while (1) {
-		DWORD ExitCode = 0;
-		if (!GetExitCodeThread(tid, &ExitCode)) {
-			return (int)GetLastError();
-		}
-		if (ExitCode != STILL_ACTIVE) {
-			return 0;
-		}
-	}
-}
-
-static inline void pthread_mutex_init(pthread_mutex_t *mutex, void *attr)
-{
-	*mutex = CreateMutex(NULL, FALSE, NULL);
-}
-
-static inline void pthread_mutex_lock(pthread_mutex_t *mutex)
-{
-	WaitForSingleObject(*mutex, INFINITE);
-}
-
-static inline void pthread_mutex_unlock(pthread_mutex_t *mutex)
-{
-	ReleaseMutex(*mutex);
-}
+extern LIBTYPE bool_t hdhomerun_vsprintf(char *buffer, char *end, const char *fmt, va_list ap);
+extern LIBTYPE bool_t hdhomerun_sprintf(char *buffer, char *end, const char *fmt, ...);
 
 /*
  * The console output format should be set to UTF-8, however in XP and Vista this breaks batch file processing.
  * Attempting to restore on exit fails to restore if the program is terminated by the user.
  * Solution - set the output format each printf.
  */
-static inline void console_vprintf(const char *fmt, va_list ap)
-{
-	UINT cp = GetConsoleOutputCP();
-	SetConsoleOutputCP(CP_UTF8);
-	vprintf(fmt, ap);
-	SetConsoleOutputCP(cp);
-}
+extern LIBTYPE void console_vprintf(const char *fmt, va_list ap);
+extern LIBTYPE void console_printf(const char *fmt, ...);
 
-static inline void console_printf(const char *fmt, ...)
-{
-	va_list ap;
-	va_start(ap, fmt);
-	console_vprintf(fmt, ap);
-	va_end(ap);
+#ifdef __cplusplus
 }
+#endif

--- a/third_party/SiliconDust/libhdhomerun/hdhomerun_pkt.c
+++ b/third_party/SiliconDust/libhdhomerun/hdhomerun_pkt.c
@@ -3,10 +3,10 @@
  *
  * Copyright © 2005-2006 Silicondust USA Inc. <www.silicondust.com>.
  *
- * This library is free software; you can redistribute it and/or 
+ * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
+ * version 2.1 of the License, or (at your option) any later version.
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -14,20 +14,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
- * 
- * As a special exception to the GNU Lesser General Public License,
- * you may link, statically or dynamically, an application with a
- * publicly distributed version of the Library to produce an
- * executable file containing portions of the Library, and
- * distribute that executable file under terms of your choice,
- * without any of the additional requirements listed in clause 4 of
- * the GNU Lesser General Public License.
- * 
- * By "a publicly distributed version of the Library", we mean
- * either the unmodified Library as distributed by Silicondust, or a
- * modified version of the Library that is distributed under the
- * conditions defined in the GNU Lesser General Public License.
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
 #include "hdhomerun.h"
@@ -135,6 +123,12 @@ uint8_t *hdhomerun_pkt_read_tlv(struct hdhomerun_pkt_t *pkt, uint8_t *ptag, size
 	}
 	
 	return pkt->pos + *plength;
+}
+
+void hdhomerun_pkt_read_mem(struct hdhomerun_pkt_t *pkt, void *mem, size_t length)
+{
+	memcpy(mem, pkt->pos, length);
+	pkt->pos += length;
 }
 
 void hdhomerun_pkt_write_u8(struct hdhomerun_pkt_t *pkt, uint8_t v)

--- a/third_party/SiliconDust/libhdhomerun/hdhomerun_pkt.h
+++ b/third_party/SiliconDust/libhdhomerun/hdhomerun_pkt.h
@@ -3,10 +3,10 @@
  *
  * Copyright © 2005-2006 Silicondust USA Inc. <www.silicondust.com>.
  *
- * This library is free software; you can redistribute it and/or 
+ * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
+ * version 2.1 of the License, or (at your option) any later version.
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -14,20 +14,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
- * 
- * As a special exception to the GNU Lesser General Public License,
- * you may link, statically or dynamically, an application with a
- * publicly distributed version of the Library to produce an
- * executable file containing portions of the Library, and
- * distribute that executable file under terms of your choice,
- * without any of the additional requirements listed in clause 4 of
- * the GNU Lesser General Public License.
- * 
- * By "a publicly distributed version of the Library", we mean
- * either the unmodified Library as distributed by Silicondust, or a
- * modified version of the Library that is distributed under the
- * conditions defined in the GNU Lesser General Public License.
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 #ifdef __cplusplus
 extern "C" {
@@ -138,6 +126,7 @@ extern "C" {
 #define HDHOMERUN_TAG_GETSET_VALUE 0x04
 #define HDHOMERUN_TAG_GETSET_LOCKKEY 0x15
 #define HDHOMERUN_TAG_ERROR_MESSAGE 0x05
+#define HDHOMERUN_TAG_TUNER_COUNT 0x10
 
 #define HDHOMERUN_DEVICE_TYPE_WILDCARD 0xFFFFFFFF
 #define HDHOMERUN_DEVICE_TYPE_TUNER 0x00000001
@@ -162,6 +151,7 @@ extern LIBTYPE uint16_t hdhomerun_pkt_read_u16(struct hdhomerun_pkt_t *pkt);
 extern LIBTYPE uint32_t hdhomerun_pkt_read_u32(struct hdhomerun_pkt_t *pkt);
 extern LIBTYPE size_t hdhomerun_pkt_read_var_length(struct hdhomerun_pkt_t *pkt);
 extern LIBTYPE uint8_t *hdhomerun_pkt_read_tlv(struct hdhomerun_pkt_t *pkt, uint8_t *ptag, size_t *plength);
+extern LIBTYPE void hdhomerun_pkt_read_mem(struct hdhomerun_pkt_t *pkt, void *mem, size_t length);
 
 extern LIBTYPE void hdhomerun_pkt_write_u8(struct hdhomerun_pkt_t *pkt, uint8_t v);
 extern LIBTYPE void hdhomerun_pkt_write_u16(struct hdhomerun_pkt_t *pkt, uint16_t v);

--- a/third_party/SiliconDust/libhdhomerun/hdhomerun_sock.h
+++ b/third_party/SiliconDust/libhdhomerun/hdhomerun_sock.h
@@ -1,0 +1,59 @@
+/*
+ * hdhomerun_sock.h
+ *
+ * Copyright © 2010 Silicondust USA Inc. <www.silicondust.com>.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct hdhomerun_local_ip_info_t {
+	uint32_t ip_addr;
+	uint32_t subnet_mask;
+};
+
+extern LIBTYPE int hdhomerun_local_ip_info(struct hdhomerun_local_ip_info_t ip_info_list[], int max_count);
+
+#define HDHOMERUN_SOCK_INVALID -1
+
+typedef int hdhomerun_sock_t;
+
+extern LIBTYPE hdhomerun_sock_t hdhomerun_sock_create_udp(void);
+extern LIBTYPE hdhomerun_sock_t hdhomerun_sock_create_tcp(void);
+extern LIBTYPE void hdhomerun_sock_destroy(hdhomerun_sock_t sock);
+
+extern LIBTYPE int hdhomerun_sock_getlasterror(void);
+extern LIBTYPE uint32_t hdhomerun_sock_getsockname_addr(hdhomerun_sock_t sock);
+extern LIBTYPE uint16_t hdhomerun_sock_getsockname_port(hdhomerun_sock_t sock);
+extern LIBTYPE uint32_t hdhomerun_sock_getpeername_addr(hdhomerun_sock_t sock);
+extern LIBTYPE uint32_t hdhomerun_sock_getaddrinfo_addr(hdhomerun_sock_t sock, const char *name);
+
+extern LIBTYPE bool_t hdhomerun_sock_join_multicast_group(hdhomerun_sock_t sock, uint32_t multicast_ip, uint32_t local_ip);
+extern LIBTYPE bool_t hdhomerun_sock_leave_multicast_group(hdhomerun_sock_t sock, uint32_t multicast_ip, uint32_t local_ip);
+
+extern LIBTYPE bool_t hdhomerun_sock_bind(hdhomerun_sock_t sock, uint32_t local_addr, uint16_t local_port, bool_t allow_reuse);
+extern LIBTYPE bool_t hdhomerun_sock_connect(hdhomerun_sock_t sock, uint32_t remote_addr, uint16_t remote_port, uint64_t timeout);
+
+extern LIBTYPE bool_t hdhomerun_sock_send(hdhomerun_sock_t sock, const void *data, size_t length, uint64_t timeout);
+extern LIBTYPE bool_t hdhomerun_sock_sendto(hdhomerun_sock_t sock, uint32_t remote_addr, uint16_t remote_port, const void *data, size_t length, uint64_t timeout);
+
+extern LIBTYPE bool_t hdhomerun_sock_recv(hdhomerun_sock_t sock, void *data, size_t *length, uint64_t timeout);
+extern LIBTYPE bool_t hdhomerun_sock_recvfrom(hdhomerun_sock_t sock, uint32_t *remote_addr, uint16_t *remote_port, void *data, size_t *length, uint64_t timeout);
+
+#ifdef __cplusplus
+}
+#endif

--- a/third_party/SiliconDust/libhdhomerun/hdhomerun_sock_posix.c
+++ b/third_party/SiliconDust/libhdhomerun/hdhomerun_sock_posix.c
@@ -1,0 +1,451 @@
+/*
+ * hdhomerun_sock_posix.c
+ *
+ * Copyright © 2010 Silicondust USA Inc. <www.silicondust.com>.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/*
+ * Implementation notes:
+ *
+ * API specifies timeout for each operation (or zero for non-blocking).
+ *
+ * It is not possible to rely on the OS socket timeout as this will fail to
+ * detect the command-response situation where data is sent successfully and
+ * the other end chooses not to send a response (other than the TCP ack).
+ *
+ * The select() cannot be used with high socket numbers (typically max 1024)
+ * so the code works as follows:
+ * - Use non-blocking sockets to allow operation without select.
+ * - Use select where safe (low socket numbers).
+ * - Poll with short sleep when select cannot be used safely.
+ */
+
+#include "hdhomerun.h"
+
+#include <net/if.h>
+#include <sys/ioctl.h>
+
+#ifndef SIOCGIFCONF
+#include <sys/sockio.h>
+#endif
+
+#ifndef _SIZEOF_ADDR_IFREQ
+#define _SIZEOF_ADDR_IFREQ(x) sizeof(x)
+#endif
+
+#ifndef MSG_NOSIGNAL
+#define MSG_NOSIGNAL 0
+#endif
+
+int hdhomerun_local_ip_info(struct hdhomerun_local_ip_info_t ip_info_list[], int max_count)
+{
+	int sock = socket(AF_INET, SOCK_DGRAM, 0);
+	if (sock == HDHOMERUN_SOCK_INVALID) {
+		return -1;
+	}
+
+	struct ifconf ifc;
+	size_t ifreq_buffer_size = 1024;
+
+	while (1) {
+		ifc.ifc_len = ifreq_buffer_size;
+		ifc.ifc_buf = (char *)malloc(ifreq_buffer_size);
+		if (!ifc.ifc_buf) {
+			close(sock);
+			return -1;
+		}
+
+		memset(ifc.ifc_buf, 0, ifreq_buffer_size);
+
+		if (ioctl(sock, SIOCGIFCONF, &ifc) != 0) {
+			free(ifc.ifc_buf);
+			close(sock);
+			return -1;
+		}
+
+		if (ifc.ifc_len < ifreq_buffer_size) {
+			break;
+		}
+
+		free(ifc.ifc_buf);
+		ifreq_buffer_size += 1024;
+	}
+
+	char *ptr = ifc.ifc_buf;
+	char *end = ifc.ifc_buf + ifc.ifc_len;
+
+	int count = 0;
+	while (ptr < end) {
+		struct ifreq *ifr = (struct ifreq *)ptr;
+		ptr += _SIZEOF_ADDR_IFREQ(*ifr);
+
+		/* Flags. */
+		if (ioctl(sock, SIOCGIFFLAGS, ifr) != 0) {
+			continue;
+		}
+
+		if ((ifr->ifr_flags & IFF_UP) == 0) {
+			continue;
+		}
+		if ((ifr->ifr_flags & IFF_RUNNING) == 0) {
+			continue;
+		}
+
+		/* Local IP address. */
+		if (ioctl(sock, SIOCGIFADDR, ifr) != 0) {
+			continue;
+		}
+
+		struct sockaddr_in *ip_addr_in = (struct sockaddr_in *)&(ifr->ifr_addr);
+		uint32_t ip_addr = ntohl(ip_addr_in->sin_addr.s_addr);
+		if (ip_addr == 0) {
+			continue;
+		}
+
+		/* Subnet mask. */
+		if (ioctl(sock, SIOCGIFNETMASK, ifr) != 0) {
+			continue;
+		}
+
+		struct sockaddr_in *subnet_mask_in = (struct sockaddr_in *)&(ifr->ifr_addr);
+		uint32_t subnet_mask = ntohl(subnet_mask_in->sin_addr.s_addr);
+
+		/* Report. */
+		if (count < max_count) {
+			struct hdhomerun_local_ip_info_t *ip_info = &ip_info_list[count];
+			ip_info->ip_addr = ip_addr;
+			ip_info->subnet_mask = subnet_mask;
+		}
+
+		count++;
+	}
+
+	free(ifc.ifc_buf);
+	close(sock);
+	return count;
+}
+
+hdhomerun_sock_t hdhomerun_sock_create_udp(void)
+{
+	/* Create socket. */
+	hdhomerun_sock_t sock = (hdhomerun_sock_t)socket(AF_INET, SOCK_DGRAM, 0);
+	if (sock == -1) {
+		return HDHOMERUN_SOCK_INVALID;
+	}
+
+	/* Set non-blocking */
+	if (fcntl(sock, F_SETFL, O_NONBLOCK) != 0) {
+		close(sock);
+		return HDHOMERUN_SOCK_INVALID;
+	}
+
+	/* Allow broadcast. */
+	int sock_opt = 1;
+	setsockopt(sock, SOL_SOCKET, SO_BROADCAST, (char *)&sock_opt, sizeof(sock_opt));
+
+	/* Success. */
+	return sock;
+}
+
+hdhomerun_sock_t hdhomerun_sock_create_tcp(void)
+{
+	/* Create socket. */
+	hdhomerun_sock_t sock = (hdhomerun_sock_t)socket(AF_INET, SOCK_STREAM, 0);
+	if (sock == -1) {
+		return HDHOMERUN_SOCK_INVALID;
+	}
+
+	/* Set non-blocking */
+	if (fcntl(sock, F_SETFL, O_NONBLOCK) != 0) {
+		close(sock);
+		return HDHOMERUN_SOCK_INVALID;
+	}
+
+	/* Success. */
+	return sock;
+}
+
+void hdhomerun_sock_destroy(hdhomerun_sock_t sock)
+{
+	close(sock);
+}
+
+int hdhomerun_sock_getlasterror(void)
+{
+	return errno;
+}
+
+uint32_t hdhomerun_sock_getsockname_addr(hdhomerun_sock_t sock)
+{
+	struct sockaddr_in sock_addr;
+	socklen_t sockaddr_size = sizeof(sock_addr);
+
+	if (getsockname(sock, (struct sockaddr *)&sock_addr, &sockaddr_size) != 0) {
+		return 0;
+	}
+
+	return ntohl(sock_addr.sin_addr.s_addr);
+}
+
+uint16_t hdhomerun_sock_getsockname_port(hdhomerun_sock_t sock)
+{
+	struct sockaddr_in sock_addr;
+	socklen_t sockaddr_size = sizeof(sock_addr);
+
+	if (getsockname(sock, (struct sockaddr *)&sock_addr, &sockaddr_size) != 0) {
+		return 0;
+	}
+
+	return ntohs(sock_addr.sin_port);
+}
+
+uint32_t hdhomerun_sock_getpeername_addr(hdhomerun_sock_t sock)
+{
+	struct sockaddr_in sock_addr;
+	socklen_t sockaddr_size = sizeof(sock_addr);
+
+	if (getpeername(sock, (struct sockaddr *)&sock_addr, &sockaddr_size) != 0) {
+		return 0;
+	}
+
+	return ntohl(sock_addr.sin_addr.s_addr);
+}
+
+uint32_t hdhomerun_sock_getaddrinfo_addr(hdhomerun_sock_t sock, const char *name)
+{
+	struct addrinfo hints;
+	memset(&hints, 0, sizeof(hints));
+	hints.ai_family = AF_INET;
+	hints.ai_socktype = SOCK_STREAM;
+	hints.ai_protocol = IPPROTO_TCP;
+
+	struct addrinfo *sock_info;
+	if (getaddrinfo(name, NULL, &hints, &sock_info) != 0) {
+		return 0;
+	}
+
+	struct sockaddr_in *sock_addr = (struct sockaddr_in *)sock_info->ai_addr;
+	uint32_t addr = ntohl(sock_addr->sin_addr.s_addr);
+
+	freeaddrinfo(sock_info);
+	return addr;
+}
+
+bool_t hdhomerun_sock_join_multicast_group(hdhomerun_sock_t sock, uint32_t multicast_ip, uint32_t local_ip)
+{
+	struct ip_mreq imr;
+	memset(&imr, 0, sizeof(imr));
+	imr.imr_multiaddr.s_addr  = htonl(multicast_ip);
+	imr.imr_interface.s_addr  = htonl(local_ip);
+
+	if (setsockopt(sock, IPPROTO_IP, IP_ADD_MEMBERSHIP, (const char *)&imr, sizeof(imr)) != 0) {
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+bool_t hdhomerun_sock_leave_multicast_group(hdhomerun_sock_t sock, uint32_t multicast_ip, uint32_t local_ip)
+{
+	struct ip_mreq imr;
+	memset(&imr, 0, sizeof(imr));
+	imr.imr_multiaddr.s_addr  = htonl(multicast_ip);
+	imr.imr_interface.s_addr  = htonl(local_ip);
+
+	if (setsockopt(sock, IPPROTO_IP, IP_DROP_MEMBERSHIP, (const char *)&imr, sizeof(imr)) != 0) {
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+bool_t hdhomerun_sock_bind(hdhomerun_sock_t sock, uint32_t local_addr, uint16_t local_port, bool_t allow_reuse)
+{
+	int sock_opt = allow_reuse;
+	setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (char *)&sock_opt, sizeof(sock_opt));
+
+	struct sockaddr_in sock_addr;
+	memset(&sock_addr, 0, sizeof(sock_addr));
+	sock_addr.sin_family = AF_INET;
+	sock_addr.sin_addr.s_addr = htonl(local_addr);
+	sock_addr.sin_port = htons(local_port);
+
+	if (bind(sock, (struct sockaddr *)&sock_addr, sizeof(sock_addr)) != 0) {
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+static bool_t hdhomerun_sock_wait_for_event(hdhomerun_sock_t sock, short event_type, uint64_t stop_time)
+{
+	uint64_t current_time = getcurrenttime();
+	if (current_time >= stop_time) {
+		return FALSE;
+	}
+
+	struct pollfd poll_event;
+	poll_event.fd = sock;
+	poll_event.events = event_type;
+	poll_event.revents = 0;
+
+	uint64_t timeout = stop_time - current_time;
+
+	if (poll(&poll_event, 1, (int)timeout) <= 0) {
+		return FALSE;
+	}
+
+	if ((poll_event.revents & event_type) == 0) {
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+bool_t hdhomerun_sock_connect(hdhomerun_sock_t sock, uint32_t remote_addr, uint16_t remote_port, uint64_t timeout)
+{
+	struct sockaddr_in sock_addr;
+	memset(&sock_addr, 0, sizeof(sock_addr));
+	sock_addr.sin_family = AF_INET;
+	sock_addr.sin_addr.s_addr = htonl(remote_addr);
+	sock_addr.sin_port = htons(remote_port);
+
+	if (connect(sock, (struct sockaddr *)&sock_addr, sizeof(sock_addr)) != 0) {
+		if ((errno != EAGAIN) && (errno != EWOULDBLOCK) && (errno != EINPROGRESS)) {
+			return FALSE;
+		}
+	}
+
+	uint64_t stop_time = getcurrenttime() + timeout;
+	return hdhomerun_sock_wait_for_event(sock, POLLOUT, stop_time);
+}
+
+bool_t hdhomerun_sock_send(hdhomerun_sock_t sock, const void *data, size_t length, uint64_t timeout)
+{
+	uint64_t stop_time = getcurrenttime() + timeout;
+	const uint8_t *ptr = (const uint8_t *)data;
+
+	while (1) {
+		int ret = send(sock, ptr, length, MSG_NOSIGNAL);
+		if (ret <= 0) {
+			if ((errno != EAGAIN) && (errno != EWOULDBLOCK) && (errno != EINPROGRESS)) {
+				return FALSE;
+			}
+			if (!hdhomerun_sock_wait_for_event(sock, POLLOUT, stop_time)) {
+				return FALSE;
+			}
+			continue;
+		}
+
+		if (ret < (int)length) {
+			ptr += ret;
+			length -= ret;
+			continue;
+		}
+
+		return TRUE;
+	}
+}
+
+bool_t hdhomerun_sock_sendto(hdhomerun_sock_t sock, uint32_t remote_addr, uint16_t remote_port, const void *data, size_t length, uint64_t timeout)
+{
+	uint64_t stop_time = getcurrenttime() + timeout;
+	const uint8_t *ptr = (const uint8_t *)data;
+
+	while (1) {
+		struct sockaddr_in sock_addr;
+		memset(&sock_addr, 0, sizeof(sock_addr));
+		sock_addr.sin_family = AF_INET;
+		sock_addr.sin_addr.s_addr = htonl(remote_addr);
+		sock_addr.sin_port = htons(remote_port);
+
+		int ret = sendto(sock, ptr, length, 0, (struct sockaddr *)&sock_addr, sizeof(sock_addr));
+		if (ret <= 0) {
+			if ((errno != EAGAIN) && (errno != EWOULDBLOCK) && (errno != EINPROGRESS)) {
+				return FALSE;
+			}
+			if (!hdhomerun_sock_wait_for_event(sock, POLLOUT, stop_time)) {
+				return FALSE;
+			}
+			continue;
+		}
+
+		if (ret < (int)length) {
+			ptr += ret;
+			length -= ret;
+			continue;
+		}
+
+		return TRUE;
+	}
+}
+
+bool_t hdhomerun_sock_recv(hdhomerun_sock_t sock, void *data, size_t *length, uint64_t timeout)
+{
+	uint64_t stop_time = getcurrenttime() + timeout;
+
+	while (1) {
+		int ret = recv(sock, data, *length, 0);
+		if (ret < 0) {
+			if ((errno != EAGAIN) && (errno != EWOULDBLOCK) && (errno != EINPROGRESS)) {
+				return FALSE;
+			}
+			if (!hdhomerun_sock_wait_for_event(sock, POLLIN, stop_time)) {
+				return FALSE;
+			}
+			continue;
+		}
+
+		if (ret == 0) {
+			return FALSE;
+		}
+
+		*length = ret;
+		return TRUE;
+	}
+}
+
+bool_t hdhomerun_sock_recvfrom(hdhomerun_sock_t sock, uint32_t *remote_addr, uint16_t *remote_port, void *data, size_t *length, uint64_t timeout)
+{
+	uint64_t stop_time = getcurrenttime() + timeout;
+
+	while (1) {
+		struct sockaddr_in sock_addr;
+		memset(&sock_addr, 0, sizeof(sock_addr));
+		socklen_t sockaddr_size = sizeof(sock_addr);
+
+		int ret = recvfrom(sock, data, *length, 0, (struct sockaddr *)&sock_addr, &sockaddr_size);
+		if (ret < 0) {
+			if ((errno != EAGAIN) && (errno != EWOULDBLOCK) && (errno != EINPROGRESS)) {
+				return FALSE;
+			}
+			if (!hdhomerun_sock_wait_for_event(sock, POLLIN, stop_time)) {
+				return FALSE;
+			}
+			continue;
+		}
+
+		if (ret == 0) {
+			return FALSE;
+		}
+
+		*remote_addr = ntohl(sock_addr.sin_addr.s_addr);
+		*remote_port = ntohs(sock_addr.sin_port);
+		*length = ret;
+		return TRUE;
+	}
+}

--- a/third_party/SiliconDust/libhdhomerun/hdhomerun_sock_windows.c
+++ b/third_party/SiliconDust/libhdhomerun/hdhomerun_sock_windows.c
@@ -1,0 +1,450 @@
+/*
+ * hdhomerun_sock_windows.c
+ *
+ * Copyright © 2010 Silicondust USA Inc. <www.silicondust.com>.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/*
+ * Implementation notes:
+ *
+ * API specifies timeout for each operation (or zero for non-blocking).
+ *
+ * It is not possible to rely on the OS socket timeout as this will fail to
+ * detect the command-response situation where data is sent successfully and
+ * the other end chooses not to send a response (other than the TCP ack).
+ *
+ * Windows supports select() however native WSA events are used to:
+ * - avoid problems with socket numbers above 1024.
+ * - wait without allowing other events handlers to run (important for use
+ *   with win7 WMC).
+ */
+
+#include "hdhomerun.h"
+#include <windows.h>
+#include <iphlpapi.h>
+
+int hdhomerun_local_ip_info(struct hdhomerun_local_ip_info_t ip_info_list[], int max_count)
+{
+	PIP_ADAPTER_INFO AdapterInfo;
+	ULONG AdapterInfoLength = sizeof(IP_ADAPTER_INFO) * 16;
+
+	while (1) {
+		AdapterInfo = (IP_ADAPTER_INFO *)malloc(AdapterInfoLength);
+		if (!AdapterInfo) {
+			return -1;
+		}
+
+		ULONG LengthNeeded = AdapterInfoLength;
+		DWORD Ret = GetAdaptersInfo(AdapterInfo, &LengthNeeded);
+		if (Ret == NO_ERROR) {
+			break;
+		}
+
+		free(AdapterInfo);
+
+		if (Ret != ERROR_BUFFER_OVERFLOW) {
+			return -1;
+		}
+		if (AdapterInfoLength >= LengthNeeded) {
+			return -1;
+		}
+
+		AdapterInfoLength = LengthNeeded;
+	}
+
+	int count = 0;
+	PIP_ADAPTER_INFO Adapter = AdapterInfo;
+	while (Adapter) {
+		IP_ADDR_STRING *IPAddr = &Adapter->IpAddressList;
+		while (IPAddr) {
+			uint32_t ip_addr = ntohl(inet_addr(IPAddr->IpAddress.String));
+			uint32_t subnet_mask = ntohl(inet_addr(IPAddr->IpMask.String));
+
+			if (ip_addr == 0) {
+				IPAddr = IPAddr->Next;
+				continue;
+			}
+
+			if (count < max_count) {
+				struct hdhomerun_local_ip_info_t *ip_info = &ip_info_list[count];
+				ip_info->ip_addr = ip_addr;
+				ip_info->subnet_mask = subnet_mask;
+			}
+
+			count++;
+			IPAddr = IPAddr->Next;
+		}
+
+		if (count >= max_count) {
+			break;
+		}
+
+		Adapter = Adapter->Next;
+	}
+
+	free(AdapterInfo);
+	return count;
+}
+
+hdhomerun_sock_t hdhomerun_sock_create_udp(void)
+{
+	/* Create socket. */
+	hdhomerun_sock_t sock = (hdhomerun_sock_t)socket(AF_INET, SOCK_DGRAM, 0);
+	if (sock == -1) {
+		return HDHOMERUN_SOCK_INVALID;
+	}
+
+	/* Set non-blocking */
+	unsigned long mode = 1;
+	if (ioctlsocket(sock, FIONBIO, &mode) != 0) {
+		closesocket(sock);
+		return HDHOMERUN_SOCK_INVALID;
+	}
+
+	/* Allow broadcast. */
+	int sock_opt = 1;
+	setsockopt(sock, SOL_SOCKET, SO_BROADCAST, (char *)&sock_opt, sizeof(sock_opt));
+
+	/* Success. */
+	return sock;
+}
+
+hdhomerun_sock_t hdhomerun_sock_create_tcp(void)
+{
+	/* Create socket. */
+	hdhomerun_sock_t sock = (hdhomerun_sock_t)socket(AF_INET, SOCK_STREAM, 0);
+	if (sock == -1) {
+		return HDHOMERUN_SOCK_INVALID;
+	}
+
+	/* Set non-blocking */
+	unsigned long mode = 1;
+	if (ioctlsocket(sock, FIONBIO, &mode) != 0) {
+		closesocket(sock);
+		return HDHOMERUN_SOCK_INVALID;
+	}
+
+	/* Success. */
+	return sock;
+}
+
+void hdhomerun_sock_destroy(hdhomerun_sock_t sock)
+{
+	closesocket(sock);
+}
+
+int hdhomerun_sock_getlasterror(void)
+{
+	return WSAGetLastError();
+}
+
+uint32_t hdhomerun_sock_getsockname_addr(hdhomerun_sock_t sock)
+{
+	struct sockaddr_in sock_addr;
+	int sockaddr_size = sizeof(sock_addr);
+
+	if (getsockname(sock, (struct sockaddr *)&sock_addr, &sockaddr_size) != 0) {
+		return 0;
+	}
+
+	return ntohl(sock_addr.sin_addr.s_addr);
+}
+
+uint16_t hdhomerun_sock_getsockname_port(hdhomerun_sock_t sock)
+{
+	struct sockaddr_in sock_addr;
+	int sockaddr_size = sizeof(sock_addr);
+
+	if (getsockname(sock, (struct sockaddr *)&sock_addr, &sockaddr_size) != 0) {
+		return 0;
+	}
+
+	return ntohs(sock_addr.sin_port);
+}
+
+uint32_t hdhomerun_sock_getpeername_addr(hdhomerun_sock_t sock)
+{
+	struct sockaddr_in sock_addr;
+	int sockaddr_size = sizeof(sock_addr);
+
+	if (getpeername(sock, (struct sockaddr *)&sock_addr, &sockaddr_size) != 0) {
+		return 0;
+	}
+
+	return ntohl(sock_addr.sin_addr.s_addr);
+}
+
+uint32_t hdhomerun_sock_getaddrinfo_addr(hdhomerun_sock_t sock, const char *name)
+{
+	struct addrinfo hints;
+	memset(&hints, 0, sizeof(hints));
+	hints.ai_family = AF_INET;
+	hints.ai_socktype = SOCK_STREAM;
+	hints.ai_protocol = IPPROTO_TCP;
+
+	struct addrinfo *sock_info;
+	if (getaddrinfo(name, NULL, &hints, &sock_info) != 0) {
+		return 0;
+	}
+
+	struct sockaddr_in *sock_addr = (struct sockaddr_in *)sock_info->ai_addr;
+	uint32_t addr = ntohl(sock_addr->sin_addr.s_addr);
+
+	freeaddrinfo(sock_info);
+	return addr;
+}
+
+bool_t hdhomerun_sock_join_multicast_group(hdhomerun_sock_t sock, uint32_t multicast_ip, uint32_t local_ip)
+{
+	struct ip_mreq imr;
+	memset(&imr, 0, sizeof(imr));
+	imr.imr_multiaddr.s_addr  = htonl(multicast_ip);
+	imr.imr_interface.s_addr  = htonl(local_ip);
+
+	if (setsockopt(sock, IPPROTO_IP, IP_ADD_MEMBERSHIP, (const char *)&imr, sizeof(imr)) != 0) {
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+bool_t hdhomerun_sock_leave_multicast_group(hdhomerun_sock_t sock, uint32_t multicast_ip, uint32_t local_ip)
+{
+	struct ip_mreq imr;
+	memset(&imr, 0, sizeof(imr));
+	imr.imr_multiaddr.s_addr  = htonl(multicast_ip);
+	imr.imr_interface.s_addr  = htonl(local_ip);
+
+	if (setsockopt(sock, IPPROTO_IP, IP_DROP_MEMBERSHIP, (const char *)&imr, sizeof(imr)) != 0) {
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+bool_t hdhomerun_sock_bind(hdhomerun_sock_t sock, uint32_t local_addr, uint16_t local_port, bool_t allow_reuse)
+{
+	int sock_opt = allow_reuse;
+	setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (char *)&sock_opt, sizeof(sock_opt));
+
+	struct sockaddr_in sock_addr;
+	memset(&sock_addr, 0, sizeof(sock_addr));
+	sock_addr.sin_family = AF_INET;
+	sock_addr.sin_addr.s_addr = htonl(local_addr);
+	sock_addr.sin_port = htons(local_port);
+
+	if (bind(sock, (struct sockaddr *)&sock_addr, sizeof(sock_addr)) != 0) {
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+bool_t hdhomerun_sock_connect(hdhomerun_sock_t sock, uint32_t remote_addr, uint16_t remote_port, uint64_t timeout)
+{
+	/* Connect (non-blocking). */
+	struct sockaddr_in sock_addr;
+	memset(&sock_addr, 0, sizeof(sock_addr));
+	sock_addr.sin_family = AF_INET;
+	sock_addr.sin_addr.s_addr = htonl(remote_addr);
+	sock_addr.sin_port = htons(remote_port);
+
+	if (connect(sock, (struct sockaddr *)&sock_addr, sizeof(sock_addr)) != 0) {
+		if (WSAGetLastError() != WSAEWOULDBLOCK) {
+			return FALSE;
+		}
+	}
+
+	/* Wait for connect to complete (both success and failure will signal). */
+	WSAEVENT wsa_event = WSACreateEvent();
+	if (wsa_event == WSA_INVALID_EVENT) {
+		return FALSE;
+	}
+
+	if (WSAEventSelect(sock, wsa_event, FD_WRITE | FD_CLOSE) == SOCKET_ERROR) {
+		WSACloseEvent(wsa_event);
+		return FALSE;
+	}
+
+	DWORD ret = WaitForSingleObjectEx(wsa_event, (DWORD)timeout, FALSE);
+	WSACloseEvent(wsa_event);
+	if (ret != WAIT_OBJECT_0) {
+		return FALSE;
+	}
+
+	/* Detect success/failure. */
+	wsa_event = WSACreateEvent();
+	if (wsa_event == WSA_INVALID_EVENT) {
+		return FALSE;
+	}
+
+	if (WSAEventSelect(sock, wsa_event, FD_CLOSE) == SOCKET_ERROR) {
+		WSACloseEvent(wsa_event);
+		return FALSE;
+	}
+
+	ret = WaitForSingleObjectEx(wsa_event, 0, FALSE);
+	WSACloseEvent(wsa_event);
+	if (ret == WAIT_OBJECT_0) {
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+static bool_t hdhomerun_sock_wait_for_event(hdhomerun_sock_t sock, long event_type, uint64_t stop_time)
+{
+	uint64_t current_time = getcurrenttime();
+	if (current_time >= stop_time) {
+		return FALSE;
+	}
+
+	WSAEVENT wsa_event = WSACreateEvent();
+	if (wsa_event == WSA_INVALID_EVENT) {
+		return FALSE;
+	}
+
+	if (WSAEventSelect(sock, wsa_event, event_type) == SOCKET_ERROR) {
+		WSACloseEvent(wsa_event);
+		return FALSE;
+	}
+
+	DWORD ret = WaitForSingleObjectEx(wsa_event, (DWORD)(stop_time - current_time), FALSE);
+	WSACloseEvent(wsa_event);
+
+	if (ret != WAIT_OBJECT_0) {
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+bool_t hdhomerun_sock_send(hdhomerun_sock_t sock, const void *data, size_t length, uint64_t timeout)
+{
+	uint64_t stop_time = getcurrenttime() + timeout;
+	const uint8_t *ptr = (uint8_t *)data;
+
+	while (1) {
+		int ret = send(sock, (char *)ptr, (int)length, 0);
+		if (ret <= 0) {
+			if (WSAGetLastError() != WSAEWOULDBLOCK) {
+				return FALSE;
+			}
+			if (!hdhomerun_sock_wait_for_event(sock, FD_WRITE | FD_CLOSE, stop_time)) {
+				return FALSE;
+			}
+			continue;
+		}
+
+		if (ret < (int)length) {
+			ptr += ret;
+			length -= ret;
+			continue;
+		}
+
+		return TRUE;
+	}
+}
+
+bool_t hdhomerun_sock_sendto(hdhomerun_sock_t sock, uint32_t remote_addr, uint16_t remote_port, const void *data, size_t length, uint64_t timeout)
+{
+	uint64_t stop_time = getcurrenttime() + timeout;
+	const uint8_t *ptr = (uint8_t *)data;
+
+	while (1) {
+		struct sockaddr_in sock_addr;
+		memset(&sock_addr, 0, sizeof(sock_addr));
+		sock_addr.sin_family = AF_INET;
+		sock_addr.sin_addr.s_addr = htonl(remote_addr);
+		sock_addr.sin_port = htons(remote_port);
+
+		int ret = sendto(sock, (char *)ptr, (int)length, 0, (struct sockaddr *)&sock_addr, sizeof(sock_addr));
+		if (ret <= 0) {
+			if (WSAGetLastError() != WSAEWOULDBLOCK) {
+				return FALSE;
+			}
+			if (!hdhomerun_sock_wait_for_event(sock, FD_WRITE | FD_CLOSE, stop_time)) {
+				return FALSE;
+			}
+			continue;
+		}
+
+		if (ret < (int)length) {
+			ptr += ret;
+			length -= ret;
+			continue;
+		}
+
+		return TRUE;
+	}
+}
+
+bool_t hdhomerun_sock_recv(hdhomerun_sock_t sock, void *data, size_t *length, uint64_t timeout)
+{
+	uint64_t stop_time = getcurrenttime() + timeout;
+
+	while (1) {
+		int ret = recv(sock, (char *)data, (int)(*length), 0);
+		if (ret < 0) {
+			if (WSAGetLastError() != WSAEWOULDBLOCK) {
+				return FALSE;
+			}
+			if (!hdhomerun_sock_wait_for_event(sock, FD_READ | FD_CLOSE, stop_time)) {
+				return FALSE;
+			}
+			continue;
+		}
+
+		if (ret == 0) {
+			return FALSE;
+		}
+
+		*length = ret;
+		return TRUE;
+	}
+}
+
+bool_t hdhomerun_sock_recvfrom(hdhomerun_sock_t sock, uint32_t *remote_addr, uint16_t *remote_port, void *data, size_t *length, uint64_t timeout)
+{
+	uint64_t stop_time = getcurrenttime() + timeout;
+
+	while (1) {
+		struct sockaddr_in sock_addr;
+		memset(&sock_addr, 0, sizeof(sock_addr));
+		int sockaddr_size = sizeof(sock_addr);
+
+		int ret = recvfrom(sock, (char *)data, (int)(*length), 0, (struct sockaddr *)&sock_addr, &sockaddr_size);
+		if (ret < 0) {
+			if (WSAGetLastError() != WSAEWOULDBLOCK) {
+				return FALSE;
+			}
+			if (!hdhomerun_sock_wait_for_event(sock, FD_READ | FD_CLOSE, stop_time)) {
+				return FALSE;
+			}
+			continue;
+		}
+
+		if (ret == 0) {
+			return FALSE;
+		}
+
+		*remote_addr = ntohl(sock_addr.sin_addr.s_addr);
+		*remote_port = ntohs(sock_addr.sin_port);
+		*length = ret;
+		return TRUE;
+	}
+}

--- a/third_party/SiliconDust/libhdhomerun/hdhomerun_types.h
+++ b/third_party/SiliconDust/libhdhomerun/hdhomerun_types.h
@@ -3,10 +3,10 @@
  *
  * Copyright © 2008-2009 Silicondust USA Inc. <www.silicondust.com>.
  *
- * This library is free software; you can redistribute it and/or 
+ * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
+ * version 2.1 of the License, or (at your option) any later version.
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -14,20 +14,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
- * 
- * As a special exception to the GNU Lesser General Public License,
- * you may link, statically or dynamically, an application with a
- * publicly distributed version of the Library to produce an
- * executable file containing portions of the Library, and
- * distribute that executable file under terms of your choice,
- * without any of the additional requirements listed in clause 4 of
- * the GNU Lesser General Public License.
- * 
- * By "a publicly distributed version of the Library", we mean
- * either the unmodified Library as distributed by Silicondust, or a
- * modified version of the Library that is distributed under the
- * conditions defined in the GNU Lesser General Public License.
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
 #define HDHOMERUN_STATUS_COLOR_NEUTRAL	0xFFFFFFFF
@@ -51,6 +39,17 @@ struct hdhomerun_tuner_status_t {
 	uint32_t packets_per_second;
 };
 
+struct hdhomerun_tuner_vstatus_t {
+	char vchannel[32];
+	char name[32];
+	char auth[32];
+	char cci[32];
+	char cgms[32];
+	bool_t not_subscribed;
+	bool_t not_available;
+	bool_t copy_protected;
+};
+
 struct hdhomerun_channelscan_program_t {
 	char program_str[64];
 	uint16_t program_number;
@@ -70,7 +69,9 @@ struct hdhomerun_channelscan_result_t {
 	int program_count;
 	struct hdhomerun_channelscan_program_t programs[HDHOMERUN_CHANNELSCAN_MAX_PROGRAM_COUNT];
 	bool_t transport_stream_id_detected;
+	bool_t original_network_id_detected;
 	uint16_t transport_stream_id;
+	uint16_t original_network_id;
 };
 
 struct hdhomerun_plotsample_t {

--- a/third_party/SiliconDust/libhdhomerun/hdhomerun_video.c
+++ b/third_party/SiliconDust/libhdhomerun/hdhomerun_video.c
@@ -1,12 +1,12 @@
 /*
  * hdhomerun_video.c
  *
- * Copyright © 2006 Silicondust USA Inc. <www.silicondust.com>.
+ * Copyright © 2006-2010 Silicondust USA Inc. <www.silicondust.com>.
  *
- * This library is free software; you can redistribute it and/or 
+ * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
+ * version 2.1 of the License, or (at your option) any later version.
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -14,47 +14,39 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
- * 
- * As a special exception to the GNU Lesser General Public License,
- * you may link, statically or dynamically, an application with a
- * publicly distributed version of the Library to produce an
- * executable file containing portions of the Library, and
- * distribute that executable file under terms of your choice,
- * without any of the additional requirements listed in clause 4 of
- * the GNU Lesser General Public License.
- * 
- * By "a publicly distributed version of the Library", we mean
- * either the unmodified Library as distributed by Silicondust, or a
- * modified version of the Library that is distributed under the
- * conditions defined in the GNU Lesser General Public License.
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
 #include "hdhomerun.h"
 
 struct hdhomerun_video_sock_t {
 	pthread_mutex_t lock;
-	uint8_t *buffer;
-	size_t buffer_size;
+	struct hdhomerun_debug_t *dbg;
+	hdhomerun_sock_t sock;
+
 	volatile size_t head;
 	volatile size_t tail;
+	uint8_t *buffer;
+	size_t buffer_size;
 	size_t advance;
-	volatile bool_t terminate;
+
 	pthread_t thread;
-	int sock;
-	uint32_t rtp_sequence;
-	struct hdhomerun_debug_t *dbg;
+	volatile bool_t terminate;
+
 	volatile uint32_t packet_count;
 	volatile uint32_t transport_error_count;
 	volatile uint32_t network_error_count;
 	volatile uint32_t sequence_error_count;
 	volatile uint32_t overflow_error_count;
+
+	volatile uint32_t rtp_sequence;
 	volatile uint8_t sequence[0x2000];
 };
 
 static THREAD_FUNC_PREFIX hdhomerun_video_thread_execute(void *arg);
 
-struct hdhomerun_video_sock_t *hdhomerun_video_create(uint16_t listen_port, size_t buffer_size, struct hdhomerun_debug_t *dbg)
+struct hdhomerun_video_sock_t *hdhomerun_video_create(uint16_t listen_port, bool_t allow_port_reuse, size_t buffer_size, struct hdhomerun_debug_t *dbg)
 {
 	/* Create object. */
 	struct hdhomerun_video_sock_t *vs = (struct hdhomerun_video_sock_t *)calloc(1, sizeof(struct hdhomerun_video_sock_t));
@@ -64,7 +56,7 @@ struct hdhomerun_video_sock_t *hdhomerun_video_create(uint16_t listen_port, size
 	}
 
 	vs->dbg = dbg;
-	vs->sock = -1;
+	vs->sock = HDHOMERUN_SOCK_INVALID;
 	pthread_mutex_init(&vs->lock, NULL);
 
 	/* Reset sequence tracking. */
@@ -86,8 +78,8 @@ struct hdhomerun_video_sock_t *hdhomerun_video_create(uint16_t listen_port, size
 	}
 	
 	/* Create socket. */
-	vs->sock = (int)socket(AF_INET, SOCK_DGRAM, 0);
-	if (vs->sock == -1) {
+	vs->sock = hdhomerun_sock_create_udp();
+	if (vs->sock == HDHOMERUN_SOCK_INVALID) {
 		hdhomerun_debug_printf(dbg, "hdhomerun_video_create: failed to allocate socket\n");
 		goto error;
 	}
@@ -96,17 +88,8 @@ struct hdhomerun_video_sock_t *hdhomerun_video_create(uint16_t listen_port, size
 	int rx_size = 1024 * 1024;
 	setsockopt(vs->sock, SOL_SOCKET, SO_RCVBUF, (char *)&rx_size, sizeof(rx_size));
 
-	/* Set timeouts. */
-	setsocktimeout(vs->sock, SOL_SOCKET, SO_SNDTIMEO, 1000);
-	setsocktimeout(vs->sock, SOL_SOCKET, SO_RCVTIMEO, 1000);
-
 	/* Bind socket. */
-	struct sockaddr_in sock_addr;
-	memset(&sock_addr, 0, sizeof(sock_addr));
-	sock_addr.sin_family = AF_INET;
-	sock_addr.sin_addr.s_addr = htonl(INADDR_ANY);
-	sock_addr.sin_port = htons(listen_port);
-	if (bind(vs->sock, (struct sockaddr *)&sock_addr, sizeof(sock_addr)) != 0) {
+	if (!hdhomerun_sock_bind(vs->sock, INADDR_ANY, listen_port, allow_port_reuse)) {
 		hdhomerun_debug_printf(dbg, "hdhomerun_video_create: failed to bind socket (port %u)\n", listen_port);
 		goto error;
 	}
@@ -121,8 +104,8 @@ struct hdhomerun_video_sock_t *hdhomerun_video_create(uint16_t listen_port, size
 	return vs;
 
 error:
-	if (vs->sock != -1) {
-		close(vs->sock);
+	if (vs->sock != HDHOMERUN_SOCK_INVALID) {
+		hdhomerun_sock_destroy(vs->sock);
 	}
 	if (vs->buffer) {
 		free(vs->buffer);
@@ -136,22 +119,43 @@ void hdhomerun_video_destroy(struct hdhomerun_video_sock_t *vs)
 	vs->terminate = TRUE;
 	pthread_join(vs->thread, NULL);
 
-	close(vs->sock);
+	hdhomerun_sock_destroy(vs->sock);
 	free(vs->buffer);
 
 	free(vs);
 }
 
+hdhomerun_sock_t hdhomerun_video_get_sock(struct hdhomerun_video_sock_t *vs)
+{
+	return vs->sock;
+}
+
 uint16_t hdhomerun_video_get_local_port(struct hdhomerun_video_sock_t *vs)
 {
-	struct sockaddr_in sock_addr;
-	socklen_t sockaddr_size = sizeof(sock_addr);
-	if (getsockname(vs->sock, (struct sockaddr*)&sock_addr, &sockaddr_size) != 0) {
-		hdhomerun_debug_printf(vs->dbg, "hdhomerun_video_get_local_port: getsockname failed (%d)\n", sock_getlasterror);
+	uint16_t port = hdhomerun_sock_getsockname_port(vs->sock);
+	if (port == 0) {
+		hdhomerun_debug_printf(vs->dbg, "hdhomerun_video_get_local_port: getsockname failed (%d)\n", hdhomerun_sock_getlasterror());
 		return 0;
 	}
 
-	return ntohs(sock_addr.sin_port);
+	return port;
+}
+
+int hdhomerun_video_join_multicast_group(struct hdhomerun_video_sock_t *vs, uint32_t multicast_ip, uint32_t local_ip)
+{
+	if (!hdhomerun_sock_join_multicast_group(vs->sock, multicast_ip, local_ip)) {
+		hdhomerun_debug_printf(vs->dbg, "hdhomerun_video_join_multicast_group: setsockopt failed (%d)\n", hdhomerun_sock_getlasterror());
+		return -1;
+	}
+
+	return 1;
+}
+
+void hdhomerun_video_leave_multicast_group(struct hdhomerun_video_sock_t *vs, uint32_t multicast_ip, uint32_t local_ip)
+{
+	if (!hdhomerun_sock_leave_multicast_group(vs->sock, multicast_ip, local_ip)) {
+		hdhomerun_debug_printf(vs->dbg, "hdhomerun_video_leave_multicast_group: setsockopt failed (%d)\n", hdhomerun_sock_getlasterror());
+	}
 }
 
 static void hdhomerun_video_stats_ts_pkt(struct hdhomerun_video_sock_t *vs, uint8_t *ptr)
@@ -168,23 +172,22 @@ static void hdhomerun_video_stats_ts_pkt(struct hdhomerun_video_sock_t *vs, uint
 		return;
 	}
 
-	uint8_t continuity_counter = ptr[3] & 0x0F;
-	uint8_t previous_sequence = vs->sequence[packet_identifier];
+	uint8_t sequence = ptr[3] & 0x0F;
 
-	if (continuity_counter == ((previous_sequence + 1) & 0x0F)) {
-		vs->sequence[packet_identifier] = continuity_counter;
-		return;
-	}
+	uint8_t previous_sequence = vs->sequence[packet_identifier];
+	vs->sequence[packet_identifier] = sequence;
+
 	if (previous_sequence == 0xFF) {
-		vs->sequence[packet_identifier] = continuity_counter;
 		return;
 	}
-	if (continuity_counter == previous_sequence) {
+	if (sequence == ((previous_sequence + 1) & 0x0F)) {
+		return;
+	}
+	if (sequence == previous_sequence) {
 		return;
 	}
 
 	vs->sequence_error_count++;
-	vs->sequence[packet_identifier] = continuity_counter;
 }
 
 static void hdhomerun_video_parse_rtp(struct hdhomerun_video_sock_t *vs, struct hdhomerun_pkt_t *pkt)
@@ -193,16 +196,27 @@ static void hdhomerun_video_parse_rtp(struct hdhomerun_video_sock_t *vs, struct 
 	uint32_t rtp_sequence = hdhomerun_pkt_read_u16(pkt);
 	pkt->pos += 8;
 
-	if (rtp_sequence != ((vs->rtp_sequence + 1) & 0xFFFF)) {
-		if (vs->rtp_sequence != 0xFFFFFFFF) {
-			vs->network_error_count++;
+	uint32_t previous_rtp_sequence = vs->rtp_sequence;
+	vs->rtp_sequence = rtp_sequence;
 
-			/* restart pid sequence check */
-			memset((void *)vs->sequence, 0xFF, sizeof(vs->sequence));
-		}
+	/* Initial case - first packet received. */
+	if (previous_rtp_sequence == 0xFFFFFFFF) {
+		return;
 	}
 
-	vs->rtp_sequence = rtp_sequence;
+	/* Normal case - next sequence number. */
+	if (rtp_sequence == ((previous_rtp_sequence + 1) & 0xFFFF)) {
+		return;
+	}
+
+	/* Error case - sequence missed. */
+	vs->network_error_count++;
+
+	/* Restart pid sequence check after packet loss. */
+	int i;
+	for (i = 0; i < 0x2000; i++) {
+		vs->sequence[i] = 0xFF;
+	}
 }
 
 static THREAD_FUNC_PREFIX hdhomerun_video_thread_execute(void *arg)
@@ -215,7 +229,11 @@ static THREAD_FUNC_PREFIX hdhomerun_video_thread_execute(void *arg)
 		hdhomerun_pkt_reset(pkt);
 
 		/* Receive. */
-		int length = recv(vs->sock, (char *)pkt->end, VIDEO_RTP_DATA_PACKET_SIZE, 0);
+		size_t length = VIDEO_RTP_DATA_PACKET_SIZE;
+		if (!hdhomerun_sock_recv(vs->sock, pkt->end, &length, 25)) {
+			continue;
+		}
+
 		pkt->end += length;
 
 		if (length == VIDEO_RTP_DATA_PACKET_SIZE) {
@@ -224,16 +242,8 @@ static THREAD_FUNC_PREFIX hdhomerun_video_thread_execute(void *arg)
 		}
 
 		if (length != VIDEO_DATA_PACKET_SIZE) {
-			if (length > 0) {
-				/* Data received but not valid - ignore. */
-				continue;
-			}
-			if (sock_getlasterror_socktimeout) {
-				/* Wait for more data. */
-				continue;
-			}
-			vs->terminate = TRUE;
-			return NULL;
+			/* Data received but not valid - ignore. */
+			continue;
 		}
 
 		pthread_mutex_lock(&vs->lock);
@@ -266,7 +276,6 @@ static THREAD_FUNC_PREFIX hdhomerun_video_thread_execute(void *arg)
 			continue;
 		}
 
-		/* Atomic update. */
 		vs->head = head;
 
 		pthread_mutex_unlock(&vs->lock);
@@ -288,7 +297,6 @@ uint8_t *hdhomerun_video_recv(struct hdhomerun_video_sock_t *vs, size_t max_size
 			tail -= vs->buffer_size;
 		}
 	
-		/* Atomic update. */
 		vs->tail = tail;
 	}
 
@@ -331,9 +339,12 @@ void hdhomerun_video_flush(struct hdhomerun_video_sock_t *vs)
 	vs->tail = vs->head;
 	vs->advance = 0;
 
-	memset((void *)vs->sequence, 0xFF, sizeof(vs->sequence));
-
 	vs->rtp_sequence = 0xFFFFFFFF;
+
+	int i;
+	for (i = 0; i < 0x2000; i++) {
+		vs->sequence[i] = 0xFF;
+	}
 
 	vs->packet_count = 0;
 	vs->transport_error_count = 0;
@@ -349,10 +360,10 @@ void hdhomerun_video_debug_print_stats(struct hdhomerun_video_sock_t *vs)
 	struct hdhomerun_video_stats_t stats;
 	hdhomerun_video_get_stats(vs, &stats);
 
-	hdhomerun_debug_printf(vs->dbg, "video sock: pkt=%ld net=%ld te=%ld miss=%ld drop=%ld\n",
-		stats.packet_count, stats.network_error_count,
-		stats.transport_error_count, stats.sequence_error_count,
-		stats.overflow_error_count
+	hdhomerun_debug_printf(vs->dbg, "video sock: pkt=%u net=%u te=%u miss=%u drop=%u\n",
+		(unsigned int)stats.packet_count, (unsigned int)stats.network_error_count,
+		(unsigned int)stats.transport_error_count, (unsigned int)stats.sequence_error_count,
+		(unsigned int)stats.overflow_error_count
 	);
 }
 

--- a/third_party/SiliconDust/libhdhomerun/hdhomerun_video.h
+++ b/third_party/SiliconDust/libhdhomerun/hdhomerun_video.h
@@ -3,10 +3,10 @@
  *
  * Copyright © 2006 Silicondust USA Inc. <www.silicondust.com>.
  *
- * This library is free software; you can redistribute it and/or 
+ * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
+ * version 2.1 of the License, or (at your option) any later version.
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -14,20 +14,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
- * 
- * As a special exception to the GNU Lesser General Public License,
- * you may link, statically or dynamically, an application with a
- * publicly distributed version of the Library to produce an
- * executable file containing portions of the Library, and
- * distribute that executable file under terms of your choice,
- * without any of the additional requirements listed in clause 4 of
- * the GNU Lesser General Public License.
- * 
- * By "a publicly distributed version of the Library", we mean
- * either the unmodified Library as distributed by Silicondust, or a
- * modified version of the Library that is distributed under the
- * conditions defined in the GNU Lesser General Public License.
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 #ifdef __cplusplus
 extern "C" {
@@ -60,7 +48,7 @@ struct hdhomerun_video_stats_t {
  *
  * When no longer needed, the socket should be destroyed by calling hdhomerun_control_destroy.
  */
-extern LIBTYPE struct hdhomerun_video_sock_t *hdhomerun_video_create(uint16_t listen_port, size_t buffer_size, struct hdhomerun_debug_t *dbg);
+extern LIBTYPE struct hdhomerun_video_sock_t *hdhomerun_video_create(uint16_t listen_port, bool_t allow_port_reuse, size_t buffer_size, struct hdhomerun_debug_t *dbg);
 extern LIBTYPE void hdhomerun_video_destroy(struct hdhomerun_video_sock_t *vs);
 
 /*
@@ -69,6 +57,12 @@ extern LIBTYPE void hdhomerun_video_destroy(struct hdhomerun_video_sock_t *vs);
  * Returns 16-bit port with native endianness, or 0 on error.
  */
 extern LIBTYPE uint16_t hdhomerun_video_get_local_port(struct hdhomerun_video_sock_t *vs);
+
+/*
+ * Join/leave multicast group.
+ */
+extern LIBTYPE int hdhomerun_video_join_multicast_group(struct hdhomerun_video_sock_t *vs, uint32_t multicast_ip, uint32_t local_ip);
+extern LIBTYPE void hdhomerun_video_leave_multicast_group(struct hdhomerun_video_sock_t *vs, uint32_t multicast_ip, uint32_t local_ip);
 
 /*
  * Read data from buffer.
@@ -99,6 +93,11 @@ extern LIBTYPE void hdhomerun_video_flush(struct hdhomerun_video_sock_t *vs);
  */
 extern LIBTYPE void hdhomerun_video_debug_print_stats(struct hdhomerun_video_sock_t *vs);
 extern LIBTYPE void hdhomerun_video_get_stats(struct hdhomerun_video_sock_t *vs, struct hdhomerun_video_stats_t *stats);
+
+/*
+ * Internal use only.
+ */
+extern LIBTYPE hdhomerun_sock_t hdhomerun_video_get_sock(struct hdhomerun_video_sock_t *vs);
 
 #ifdef __cplusplus
 }

--- a/third_party/SiliconDust/libhdhomerun/lgpl.txt
+++ b/third_party/SiliconDust/libhdhomerun/lgpl.txt
@@ -1,0 +1,502 @@
+                  GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+                            NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+  <signature of Ty Coon>, 1 April 1990
+  Ty Coon, President of Vice
+
+That's all there is to it!


### PR DESCRIPTION
I updated the libhdhomerun to the latest version. The only change for HDHomeRun.cp was the version check. I see this as a prerequisite in order to further improve some features with HDHomeRun on linux. I discovered issue with an older EU DUAL model using DVB-C (sage assumes it is only DVB-T), with my new hdhomerun3_dvbc I have 4 tuners but sage sees only 2 of them, I think there is a hard coded limit of tuner set to 2 in HDHomeRun.cp. Will do further work on this.