### PR TITLE
Add overload to redetectCaptureDevices

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,3 +10,4 @@ Google Inc.
 Christopher Piper <fuzzy@weirdness.com>
 Jason Reicheneker <jason.reicheneker@gmail.com>
 Raymond Chi <raychi@gmail.com>
+Joshua Lewis <josh@joshandmonique.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -20,3 +20,4 @@ John McDole <codefu@google.com>
 Christopher Piper <fuzzy@weirdness.com>
 Jason Reicheneker <jason.reicheneker@gmail.com>
 Raymond Chi <raychi@gmail.com>
+Joshua Lewis <josh@joshandmonique.com>

--- a/java/sage/MMC.java
+++ b/java/sage/MMC.java
@@ -103,8 +103,6 @@ public class MMC
   }
 
   // This can be used to load any new capture devices that were hotplugged after SageTV has started
-  // If you just want to load new devices for a single capture device manager you can just do
-  // updateCaptureDeviceObjects, the property sync and then the kicks
   public void redetectCaptureDevices()
   {
     if (Sage.DBG) System.out.println("MMC is re-doing the capture device detection!");
@@ -125,8 +123,8 @@ public class MMC
     Scheduler.getInstance().kick(true);
   }
   
- // This is an overload of redetectCaptureDevices.  It is meant to only redetect devices of
- // a certain type.  For instance discover NetworkEncoder devices
+ // This is an overload of redetectCaptureDevices.  It is meant to only redetect devices for
+ // one CaptureDeviceManager.  For instance discover NetworkEncoder devices
  public void redetectCaptureDevices(CaptureDeviceManager mgr)
  {
 	 if (Sage.DBG) System.out.println("MMC is re-doing the capture device detection on " + mgr);

--- a/java/sage/MMC.java
+++ b/java/sage/MMC.java
@@ -115,8 +115,8 @@ public class MMC
       mgr.detectCaptureDevices((CaptureDevice[]) globalEncoderMap.values().toArray(new CaptureDevice[0]));
       CaptureDevice[] newDevs = mgr.getCaptureDevices();
       if (Sage.DBG) System.out.println("devices detected=" + java.util.Arrays.asList(newDevs));
-      for (int j = 0; j < newDevs.length; j++)
-        globalEncoderMap.put(newDevs[j].getName(), newDevs[j]);
+     
+      updateCaptureDeviceObjects(newDevs);
 
       if (Sage.DBG) System.out.println("EncoderMap=" + globalEncoderMap);
     }
@@ -124,6 +124,23 @@ public class MMC
     Seeker.getInstance().kick();
     Scheduler.getInstance().kick(true);
   }
+  
+ // This is an overload of redetectCaptureDevices.  It is meant to only redetect devices of
+ // a certain type.  For instance discover NetworkEncoder devices
+ public void redetectCaptureDevices(CaptureDeviceManager mgr)
+ {
+	 if (Sage.DBG) System.out.println("MMC is re-doing the capture device detection on " + mgr);
+     mgr.detectCaptureDevices((CaptureDevice[]) globalEncoderMap.values().toArray(new CaptureDevice[0]));
+     CaptureDevice[] newDevs = mgr.getCaptureDevices();
+     
+     if (Sage.DBG) System.out.println("devices detected=" + java.util.Arrays.asList(newDevs));
+     updateCaptureDeviceObjects(newDevs);
+
+     if (Sage.DBG) System.out.println("EncoderMap=" + globalEncoderMap);
+     NetworkClient.distributeRecursivePropertyChange("mmc/encoders");
+     Seeker.getInstance().kick();
+     Scheduler.getInstance().kick(true);
+ }
 
   // If we're changing the actual CapDev object than we need to rebuild this map. This occurs
   // on client resync of properties

--- a/java/sage/MMC.java
+++ b/java/sage/MMC.java
@@ -127,7 +127,7 @@ public class MMC
  // one CaptureDeviceManager.  For instance discover NetworkEncoder devices
  public void redetectCaptureDevices(CaptureDeviceManager mgr)
  {
-	 if (Sage.DBG) System.out.println("MMC is re-doing the capture device detection on " + mgr);
+     if (Sage.DBG) System.out.println("MMC is re-doing the capture device detection on " + mgr);
      mgr.detectCaptureDevices((CaptureDevice[]) globalEncoderMap.values().toArray(new CaptureDevice[0]));
      CaptureDevice[] newDevs = mgr.getCaptureDevices();
      


### PR DESCRIPTION
Added an overload to redetectCaptureDevices to only detect devices on one CaptureDeviceManager.  These changes were discussed in issue "Want to be able to load a Network Encoder as a runnable class"