### PR TITLE
Log full stacktrace on EPG plugin errors

### DIFF
--- a/java/sage/EPG.java
+++ b/java/sage/EPG.java
@@ -15,7 +15,10 @@
  */
 package sage;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.lang.reflect.Constructor;
+
 import sage.Wizard.MaintenanceType;
 
 /*
@@ -1597,8 +1600,10 @@ public final class EPG implements Runnable
     }
     catch (Throwable e)
     {
-      System.out.println("Error updating with EPG Plugin:" + e);
-      return false;
+    	StringWriter sw = new StringWriter();
+    	e.printStackTrace(new PrintWriter(sw));
+    	System.out.println("Error updating with EPG Plugin:\n" + sw);
+    	return false;
     }
   }
 

--- a/java/sage/EPG.java
+++ b/java/sage/EPG.java
@@ -15,8 +15,6 @@
  */
 package sage;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.lang.reflect.Constructor;
 
 import sage.Wizard.MaintenanceType;
@@ -1600,9 +1598,8 @@ public final class EPG implements Runnable
     }
     catch (Throwable e)
     {
-    	StringWriter sw = new StringWriter();
-    	e.printStackTrace(new PrintWriter(sw));
-    	System.out.println("Error updating with EPG Plugin:\n" + sw);
+    	System.out.println("Error updating with EPG Plugin:");
+    	Sage.printStackTrace(e);
     	return false;
     }
   }


### PR DESCRIPTION
EPG thread only logs the Throwable.toString() when it catches an
exception from an EPG plugin, which isn't very helpful when tracking
down bugs.  A full stacktrace makes solving problems rather easy.