### PR TITLE
Allow for favorites to be disabled

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,3 +13,4 @@ Sean Stuckless <sean.stuckless@gmail.com>
 Raymond Chi <raychi@gmail.com>
 Joshua Lewis <josh@joshandmonique.com>
 Martin Weber Nissle <webernissle@gmail.com>
+Chris Danser <chris.danser@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -23,3 +23,4 @@ Sean Stuckless <sean.stuckless@gmail.com>
 Raymond Chi <raychi@gmail.com>
 Joshua Lewis <josh@joshandmonique.com>
 Martin Weber Nissle <webernissle@gmail.com>
+Chris Danser <chris.danser@gmail.com>

--- a/java/sage/Agent.java
+++ b/java/sage/Agent.java
@@ -560,6 +560,20 @@ public class Agent extends DBObject implements Favorite
   {
     return followsTrend(air, mustBeViewable, sbCache, false);
   }
+
+  /**
+   * Determine if the given airing meets the criteria for this Agent. (i.e. could the given Airing be scheduled because
+   * of this Agent)
+   *
+   * @param air The Airing to be tested
+   * @param mustBeViewable If true, the Airing must be viewable for this method to return true.  Viewable means a 
+   * recording that can be watched, or a channel that can be viewed.
+   * @param sbCache A StringBuffer to be used by this method.  If null a new StringBuffer will be created.  If non-null
+   * the buffer will be cleared and use.  When calling this method in a loop, the same StringBuffer can be used for each
+   * call to limit object creation and memory use.
+   * @param skipKeyword If true, keyword matching is not considered
+   * @return true if the given Airing matches this Agent (given the parameter criteria) , false otherwise.
+   */
   /*
    * TODO(codefu): skipKeyword is a hack before showcase. It works since the other flags are AND
    * tested; but we can have Lucene do this for us
@@ -570,6 +584,9 @@ public class Agent extends DBObject implements Favorite
     Show s = air.getShow();
     if (s == null) return false;
 
+    //A disabled agent doesn't match any airings
+    if(testAgentFlag(DISABLED_FLAG))
+        return false;
     // Do not be case sensitive when checking titles!! We got a bunch of complaints about this on our forums.
     // Don't let null titles match all the Favorites!
     if (title != null && (s.title == null || (s.title != null && title != s.title && !title.toString().equalsIgnoreCase(s.title.toString()))))

--- a/java/sage/Agent.java
+++ b/java/sage/Agent.java
@@ -64,6 +64,7 @@ public class Agent extends DBObject implements Favorite
   public static final int DONT_AUTODELETE_FLAG = 0x01;
   public static final int KEEP_AT_MOST_MASK = 0x7E; // 6 bits
   public static final int DELETE_AFTER_CONVERT_FLAG = 0x80;
+  public static final int DISABLED_FLAG = 0x100;
 
   String getNameForType()
   {
@@ -325,6 +326,7 @@ public class Agent extends DBObject implements Favorite
     int keepAtMost = getAgentFlag(KEEP_AT_MOST_MASK);
     if (keepAtMost > 0)
       sb.append(" keep=").append(keepAtMost);
+    sb.append(" enabled=").append(!testAgentFlag(DISABLED_FLAG));
     sb.append(']');
     return sb.toString();
   }
@@ -1210,10 +1212,12 @@ public class Agent extends DBObject implements Favorite
       return agentFlags & DONT_AUTODELETE_FLAG;
     else if (whichFlag == KEEP_AT_MOST_MASK)
       return (agentFlags & KEEP_AT_MOST_MASK) >> 1;
-        else if (whichFlag == DELETE_AFTER_CONVERT_FLAG)
-          return agentFlags & DELETE_AFTER_CONVERT_FLAG;
-        else
-          return 0;
+    else if (whichFlag == DELETE_AFTER_CONVERT_FLAG)
+      return agentFlags & DELETE_AFTER_CONVERT_FLAG;
+    else if (whichFlag == DISABLED_FLAG)
+      return agentFlags & DISABLED_FLAG;
+    else
+      return 0;
   }
   void setAgentFlags(int maskBits, int values)
   {

--- a/java/sage/Carny.java
+++ b/java/sage/Carny.java
@@ -956,7 +956,7 @@ public final class Carny implements Runnable
         }
       }
       Agent currAgent = (Agent) allAgents[i];
-      if (currAgent == null)
+      if (currAgent == null || currAgent.testAgentFlag(Agent.DISABLED_FLAG))
         continue;
 
       if ((!doneInit && Sage.getBoolean("limited_carny_init", Sage.EMBEDDED)) ||

--- a/java/sage/Carny.java
+++ b/java/sage/Carny.java
@@ -262,6 +262,20 @@ public final class Carny implements Runnable
       rv.setStopPadding(defaultFavoriteStopPadding);
     }
 
+    handleAddedFavorite(rv);
+
+    submitJob(new Object[] { LOVE_JOB, null });
+    sage.plugin.PluginEventManager.postEvent(sage.plugin.PluginEventManager.FAVORITE_ADDED,
+        new Object[] { sage.plugin.PluginEventManager.VAR_FAVORITE, rv });
+    return rv;
+  }
+
+  /**
+   * Update the internal Carny state after a favorite has been added (or enabled)
+   * @param rv The Favorite that was updated
+   */
+  private void handleAddedFavorite(Agent rv)
+  {
     // LOVESET UPDATE Make the updates to the loveSet that need to be & sync the clients
     // For add, we just add all of the Airings that match this Favorite to the loveAirSet
     List<Airing> airsToAdd = new ArrayList<Airing>();
@@ -338,11 +352,8 @@ public final class Carny implements Runnable
       clientSyncAll();
       Scheduler.getInstance().kick(true);
     }
-    submitJob(new Object[] { LOVE_JOB, null });
-    sage.plugin.PluginEventManager.postEvent(sage.plugin.PluginEventManager.FAVORITE_ADDED,
-        new Object[] { sage.plugin.PluginEventManager.VAR_FAVORITE, rv });
-    return rv;
   }
+
   public Agent updateFavorite(Agent fav, int agentMask, String title, String category, String subCategory,
       Person person, int role, String rated, String year, String pr, String network,
       String chanName, int slotType, int[] timeslots, String keyword)
@@ -537,6 +548,21 @@ public final class Carny implements Runnable
     } finally {
       wiz.releaseWriteLock(Wizard.AGENT_CODE);
     }
+
+    handleRemovedFavorite(fav, allFavs);
+
+    submitJob(new Object[] { LOVE_JOB, null });
+    sage.plugin.PluginEventManager.postEvent(sage.plugin.PluginEventManager.FAVORITE_REMOVED,
+        new Object[] { sage.plugin.PluginEventManager.VAR_FAVORITE, fav });
+  }
+
+  /**
+   * Update the internal Carny state after a favorite has been removed (or disabled)
+   * @param fav The Favorite that was removed
+   * @param allFavs The collection of all Favorites
+   */
+  private void handleRemovedFavorite(Agent fav, List<Agent> allFavs)
+  {
     // LOVESET UPDATE Make the updates to the loveSet that need to be & sync the clients
     List<Airing> airsThatMayDie = new ArrayList<Airing>();
     DBObject[] airs;
@@ -614,9 +640,33 @@ public final class Carny implements Runnable
     }
 
     clientSyncLoves();
-    submitJob(new Object[] { LOVE_JOB, null });
-    sage.plugin.PluginEventManager.postEvent(sage.plugin.PluginEventManager.FAVORITE_REMOVED,
-        new Object[] { sage.plugin.PluginEventManager.VAR_FAVORITE, fav });
+  }
+
+  /**
+   * Set the enabled/disabled state of a favorite
+   * @param fav The Favorite to enable/disable
+   * @param enabled true if the given favorite should be enabled, false if it should be disabled
+   */
+  public void enableFavorite(Agent fav, boolean enabled)
+  {
+      //If the DISabled flag is equal to the ENabled parameter, then the call to this function should
+      //  change the state of the given Agent, otherwise nothing changes
+      if(fav.testAgentFlag(Agent.DISABLED_FLAG) == enabled)
+      {
+          //first update the agent flag
+          setAgentFlags(fav, Agent.DISABLED_FLAG, enabled?0:Agent.DISABLED_FLAG);
+
+          //Next update the Carny internal state
+          if(enabled) {
+              handleAddedFavorite(fav);
+          } else {
+              handleRemovedFavorite(fav, Arrays.asList(Wizard.getInstance().getFavorites()));
+          }
+
+          submitJob(new Object[] { LOVE_JOB, null });
+          sage.plugin.PluginEventManager.postEvent(sage.plugin.PluginEventManager.FAVORITE_MODIFIED,
+              new Object[] { sage.plugin.PluginEventManager.VAR_FAVORITE, fav });
+      }
   }
 
   private void clientSyncAll()

--- a/java/sage/api/FavoriteAPI.java
+++ b/java/sage/api/FavoriteAPI.java
@@ -980,7 +980,7 @@ public class FavoriteAPI {
           Agent a = (Agent) stack.pop();
           if (Permissions.hasPermission(Permissions.PERMISSION_RECORDINGSCHEDULE, stack.getUIMgr()))
           {
-              Carny.getInstance().setAgentFlags(a, Agent.DISABLED_FLAG, b?0:Agent.DISABLED_FLAG);
+              Carny.getInstance().enableFavorite(a, b);
               Carny.getInstance().kick();
           }
           return null;

--- a/java/sage/api/FavoriteAPI.java
+++ b/java/sage/api/FavoriteAPI.java
@@ -113,6 +113,21 @@ public class FavoriteAPI {
       public Object runSafely(Catbert.FastStack stack) throws Exception{
         return Boolean.valueOf(((Agent) stack.pop()).testAgentFlag(Agent.DELETE_AFTER_CONVERT_FLAG));
       }});
+    rft.put(new PredefinedJEPFunction("Favorite", "IsEnabled", 1, new String[] { "Favorite" })
+    {
+      /**
+       * Returns true if SageTV considers this favorite when performing scheduling.
+       * @param Favorite the Favorite object
+       * @return true if this Favorite is enabled, false otherwise
+       * @since 9.0
+       *
+       * @declaration   public boolean IsEnabled(Favorite Favorite);
+       */
+        @Override
+        public Object runSafely(Catbert.FastStack stack) throws Exception{
+            //Note here that the value of the test is negated
+            return Boolean.valueOf(!((Agent) stack.pop()).testAgentFlag(Agent.DISABLED_FLAG));
+        }});
     rft.put(new PredefinedJEPFunction("Favorite", "GetKeepAtMost", 1, new String[] { "Favorite" })
     {
       /**
@@ -948,6 +963,27 @@ public class FavoriteAPI {
         }
         else
           return Boolean.FALSE;
+      }});
+    rft.put(new PredefinedJEPFunction("Favorite", "SetEnabled", 2, new String[] { "Favorite", "Enabled" }, true)
+    {
+      /**
+       * Sets whether or not SageTV will use this favorite when scheduling recordings
+       * @param Favorite the Favorite object
+       * @param Enabled true if this Favorite is to be used for scheduling, false otherwise
+       * @since 9.0
+       *
+       * @declaration   public void SetEnabled(Favorite Favorite, boolean Enabled);
+       */
+      @Override
+      public Object runSafely(Catbert.FastStack stack) throws Exception{
+          boolean b = evalBool(stack.pop());
+          Agent a = (Agent) stack.pop();
+          if (Permissions.hasPermission(Permissions.PERMISSION_RECORDINGSCHEDULE, stack.getUIMgr()))
+          {
+              Carny.getInstance().setAgentFlags(a, Agent.DISABLED_FLAG, b?0:Agent.DISABLED_FLAG);
+              Carny.getInstance().kick();
+          }
+          return null;
       }});
     rft.put(new PredefinedJEPFunction("Favorite", "GetFavoriteForAiring", 1, new String[] { "Airing" })
     {

--- a/java/sage/api/FavoriteAPI.java
+++ b/java/sage/api/FavoriteAPI.java
@@ -113,7 +113,7 @@ public class FavoriteAPI {
       public Object runSafely(Catbert.FastStack stack) throws Exception{
         return Boolean.valueOf(((Agent) stack.pop()).testAgentFlag(Agent.DELETE_AFTER_CONVERT_FLAG));
       }});
-    rft.put(new PredefinedJEPFunction("Favorite", "IsEnabled", 1, new String[] { "Favorite" })
+    rft.put(new PredefinedJEPFunction("Favorite", "IsFavoriteEnabled", 1, new String[] { "Favorite" })
     {
       /**
        * Returns true if SageTV considers this favorite when performing scheduling.
@@ -121,7 +121,7 @@ public class FavoriteAPI {
        * @return true if this Favorite is enabled, false otherwise
        * @since 9.0
        *
-       * @declaration   public boolean IsEnabled(Favorite Favorite);
+       * @declaration   public boolean IsFavoriteEnabled(Favorite Favorite);
        */
         @Override
         public Object runSafely(Catbert.FastStack stack) throws Exception{
@@ -964,7 +964,7 @@ public class FavoriteAPI {
         else
           return Boolean.FALSE;
       }});
-    rft.put(new PredefinedJEPFunction("Favorite", "SetEnabled", 2, new String[] { "Favorite", "Enabled" }, true)
+    rft.put(new PredefinedJEPFunction("Favorite", "SetFavoriteEnabled", 2, new String[] { "Favorite", "Enabled" }, true)
     {
       /**
        * Sets whether or not SageTV will use this favorite when scheduling recordings
@@ -972,7 +972,7 @@ public class FavoriteAPI {
        * @param Enabled true if this Favorite is to be used for scheduling, false otherwise
        * @since 9.0
        *
-       * @declaration   public void SetEnabled(Favorite Favorite, boolean Enabled);
+       * @declaration   public void SetFavoriteEnabled(Favorite Favorite, boolean Enabled);
        */
       @Override
       public Object runSafely(Catbert.FastStack stack) throws Exception{


### PR DESCRIPTION
* Add a flag to favorites (Agent) that allows for them to be disabled.  
* Add the logic in Carny to test that flag.  
* Add API methods to query and set that flag.

Note: The Agent flag is whether or not the Agent is DISabled, because that allows the default state of the flag (0) to mean ENabled (i.e. disabled is false).  The API methods test and set whether the favorite is ENabled (which is the opposite of the Agent flag) because I thought that made more sense for a user of the API.

I'll be submitting a separate pull request with an STV update to expose this new functionality once this pull request is accepted..  I've tested with a locally modified v7 STV.  I just need to get those changes made to the latest STV from github.