### PR TITLE
Monitor lost/offline network encoders

### DIFF
--- a/java/sage/NetworkCaptureDevice.java
+++ b/java/sage/NetworkCaptureDevice.java
@@ -344,7 +344,7 @@ public final class NetworkCaptureDevice extends CaptureDevice
   public boolean isFunctioning()
   {
     boolean rv = "OK".equals(submitHostCommand("NOOP"));
-    if (Sage.EMBEDDED && !rv && !launchedMonitorThread)
+    if (!rv && !launchedMonitorThread)
     {
       if (hasConfiguredInput())
       {
@@ -362,7 +362,7 @@ public final class NetworkCaptureDevice extends CaptureDevice
                 Scheduler.getInstance().kick(false);
                 break;
               }
-              try{Thread.sleep(1000);}catch(Exception e){}
+              try{Thread.sleep((Sage.EMBEDDED) ? 1000 : 15000);}catch(Exception e){}
             }
             launchedMonitorThread = false;
           }


### PR DESCRIPTION
If a network encoder is configured and not found, it was previously ignored, unless the user navigated to the source details page, which would trigger an IsFunctioning() call.  It will now be checked for every 15 seconds, and if it starts responding, will be enabled and the scheduler kicked off.  This capability was created for the embedded platform (checking every second), but was never implemented in the standard server.