### PR TITLE
Fix: QAM channel scan is unreliable; often reports many channels as DTV-x-y

### DIFF
--- a/native/ax/Native2.0/NativeCore/ATSCPSIParser.c
+++ b/native/ax/Native2.0/NativeCore/ATSCPSIParser.c
@@ -216,10 +216,10 @@ static void UnpackVCT( ATSC_PSI* pATSCPSI, TS_SECTION* pSection )
 	}
 
 
-	p = section_header.table_data;
-	p += 1; //skip protocal version 1 bytes
-	pATSCPSI->vct_num = *p; // MAX_VCT_TBL;
-	p += 1;
+	p = section_header.table_data;  // points to byte[8], 'protocol version' field
+	p += 1;                 // skip protocol version (1 byte)
+	pATSCPSI->vct_num = *p; // MAX_VCT_TBL; num_channels_in_section
+	p += 1;                 // point to start of table
 
 	pATSCPSI->vct_program = section_header.tsid;
 	pVCT = pATSCPSI->vct;
@@ -253,7 +253,7 @@ static void UnpackVCT( ATSC_PSI* pATSCPSI, TS_SECTION* pSection )
 					  pATSCPSI->vct[i].service_type != vct.service_type ||
 					  pATSCPSI->vct[i].source_id  != vct.source_id  ||
 					  pATSCPSI->vct[i].tsid  != vct.tsid ;
-					 
+
 		if ( check_flag )
 		{
 			update_flag = 1;

--- a/native/exe/SageLauncher/SageLauncher.rc
+++ b/native/exe/SageLauncher/SageLauncher.rc
@@ -51,7 +51,7 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 9,0,0,5
+ FILEVERSION 9,0,0,6
  PRODUCTVERSION 9,0,0,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
@@ -69,7 +69,7 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "SageTV Open Source"
             VALUE "FileDescription", "SageTV"
-            VALUE "FileVersion", "9.0.0.5"
+            VALUE "FileVersion", "9.0.0.6"
             VALUE "InternalName", "SageTV"
             VALUE "LegalCopyright", "Copyright © © 2015 The SageTV Authors"
             VALUE "OriginalFilename", "SageTV.exe"


### PR DESCRIPTION
This behavior is observed when using Hauppauge HVR 1250, 1600, 1800 & 2250 tuners, although it likely occurs with any BDA (internal, non-network) tuner.  A non-Sage channel scan (TV, HDHR, or  Hauppauge WinTv app, or TsReader) confirms that the correct channel info is present in the data stream.  The issue was introduced in Sage7 and didn't occur with Sage6.  Possibly related to another old issue; see comment in ChannelScan.c re: 'QAM stream carries DVB-C PSI in Lubbock TX'.  

Suddenlink cable (clear QAM, in Truckee, Calif) carries some ATSC streams with a 12:1 ratio of DVB to ATSC packets.  This mixture of packets (which arrive in no particular order) caused the channel scanner to get confused.  Depending upon when it started looking at the pkt stream, stream_format might get set to either DVB_STREAM or ATSC_STREAM, causing programs to be reported as "DTV-x-y" instead of e.g, "KCRA", or dropped entirely.  Scan results were often inconsistent, resulting in the need to manually remap a large number of channels. Subsequent scans gave wildly different scan results.  In a system with multiple tuners using the same channel lineup, it was impossible to obtain convergence.

This commit changes the algorithm for "guessing" the stream type by giving higher weight to ATSC packets, based on a ratio of 16:1.  To guard against spurious ATSC detection, we still need to see >= 2 ATSC packets to decide it's an ATSC stream.

Pkt stream test case: 15 (DVB), 1 (ATSC), 15 (DVB), 1 (ATSC) : result=ATSC Stream detected

This commit also bumps the SageTv.exe version # from 9.0.0.5 to 9.0.0.6

I intend to encourage wider testing of this change by posting TSSplitter.ax (for both Sage7 & Sage9) on the forums after the code has been reviewed.
