### PR TITLE
Added _LARGEFILE64_SOURCE define. MUST be prior to sys/types.h and un…

### DIFF
--- a/native/ax/Native2.0/NativeCore/NativeCore.h
+++ b/native/ax/Native2.0/NativeCore/NativeCore.h
@@ -26,6 +26,8 @@ extern "C" {
 
 #define _USE_32BIT_TIME_T
 
+#define _LARGEFILE64_SOURCE
+
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 


### PR DESCRIPTION
…istd.h.

This specifically fixes issues with lseek64() returning bad values for large files on Ubuntu 14.04 LTS. Video file durations were incorrect when importing files larger than 1GB. I added this in the primary NativeCore.h to catch any other size problems with other x64 api in types.h. This should be GNU specific and have no affect on windows, but I have only tested on linux.