### PR TITLE
Manifests and version changes for launchers for Client, Server and ServiceControl

### DIFF
--- a/native/exe/MiniClientLauncher/MiniClientLauncher.rc
+++ b/native/exe/MiniClientLauncher/MiniClientLauncher.rc
@@ -1,5 +1,7 @@
-//Microsoft Developer Studio generated resource script.
+// Microsoft Visual C++ generated resource script.
 //
+#include "resource.h"
+
 #define APSTUDIO_READONLY_SYMBOLS
 /////////////////////////////////////////////////////////////////////////////
 //
@@ -11,13 +13,11 @@
 #undef APSTUDIO_READONLY_SYMBOLS
 
 /////////////////////////////////////////////////////////////////////////////
-// English (U.S.) resources
+// English (United States) resources
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
-#ifdef _WIN32
 LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 #pragma code_page(1252)
-#endif //_WIN32
 
 #ifdef APSTUDIO_INVOKED
 /////////////////////////////////////////////////////////////////////////////
@@ -25,18 +25,18 @@ LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 // TEXTINCLUDE
 //
 
-1 TEXTINCLUDE DISCARDABLE 
+1 TEXTINCLUDE
 BEGIN
     "resource.h\0"
 END
 
-2 TEXTINCLUDE DISCARDABLE 
+2 TEXTINCLUDE
 BEGIN
     "#include ""afxres.h""\r\n"
     "\0"
 END
 
-3 TEXTINCLUDE DISCARDABLE 
+3 TEXTINCLUDE
 BEGIN
     "\r\n"
     "\0"
@@ -45,15 +45,14 @@ END
 #endif    // APSTUDIO_INVOKED
 
 
-#ifndef _MAC
 /////////////////////////////////////////////////////////////////////////////
 //
 // Version
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 2,0,0,1
- PRODUCTVERSION 2,0,0,1
+ FILEVERSION 9,0,4,220
+ PRODUCTVERSION 9,0,4,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -68,18 +67,14 @@ BEGIN
     BEGIN
         BLOCK "040904b0"
         BEGIN
-            VALUE "Comments", "\0"
-            VALUE "CompanyName", "SageTV, LLC\0"
-            VALUE "FileDescription", "SageTV\0"
-            VALUE "FileVersion", "2, 0, 0, 1\0"
-            VALUE "InternalName", "SageTV\0"
-            VALUE "LegalCopyright", "Copyright © 2001-2006 Frey Technologies, LLC\0"
-            VALUE "LegalTrademarks", "\0"
-            VALUE "OriginalFilename", "SageTVMiniClient.exe\0"
-            VALUE "PrivateBuild", "\0"
-            VALUE "ProductName", "SageTV\0"
-            VALUE "ProductVersion", "2.0\0"
-            VALUE "SpecialBuild", "\0"
+            VALUE "CompanyName", "SageTV Open Source"
+            VALUE "FileDescription", "SageTV"
+            VALUE "FileVersion", "9.0.4.220"
+            VALUE "InternalName", "SageTV"
+            VALUE "LegalCopyright", "Copyright © © 2015 The SageTV Authors"
+            VALUE "OriginalFilename", "Placeshifter.exe"
+            VALUE "ProductName", "SageTV"
+            VALUE "ProductVersion", "9.0.4.0"
         END
     END
     BLOCK "VarFileInfo"
@@ -87,8 +82,6 @@ BEGIN
         VALUE "Translation", 0x409, 1200
     END
 END
-
-#endif    // !_MAC
 
 
 /////////////////////////////////////////////////////////////////////////////
@@ -98,8 +91,8 @@ END
 
 // Icon with lowest ID value placed first to ensure application icon
 // remains consistent on all systems.
-IDI_ICON1               ICON    DISCARDABLE     "SageIcon.ico"
-#endif    // English (U.S.) resources
+IDI_ICON1               ICON                    "SageIcon.ico"
+#endif    // English (United States) resources
 /////////////////////////////////////////////////////////////////////////////
 
 

--- a/native/exe/SageLauncher/SageLauncher.rc
+++ b/native/exe/SageLauncher/SageLauncher.rc
@@ -25,18 +25,18 @@ LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 // TEXTINCLUDE
 //
 
-1 TEXTINCLUDE 
+1 TEXTINCLUDE
 BEGIN
     "resource.h\0"
 END
 
-2 TEXTINCLUDE 
+2 TEXTINCLUDE
 BEGIN
     "#include ""afxres.h""\r\n"
     "\0"
 END
 
-3 TEXTINCLUDE 
+3 TEXTINCLUDE
 BEGIN
     "\r\n"
     "\0"
@@ -51,8 +51,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 9,0,0,6
- PRODUCTVERSION 9,0,0,0
+ FILEVERSION 9,0,4,220
+ PRODUCTVERSION 9,0,4,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -69,12 +69,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "SageTV Open Source"
             VALUE "FileDescription", "SageTV"
-            VALUE "FileVersion", "9.0.0.6"
+            VALUE "FileVersion", "9.0.4.220"
             VALUE "InternalName", "SageTV"
             VALUE "LegalCopyright", "Copyright © © 2015 The SageTV Authors"
             VALUE "OriginalFilename", "SageTV.exe"
             VALUE "ProductName", "SageTV"
-            VALUE "ProductVersion", "9.0.0.0"
+            VALUE "ProductVersion", "9.0.4.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/native/exe/SageLauncher/SageLauncher.vcxproj
+++ b/native/exe/SageLauncher/SageLauncher.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Client Debug|Win32">
@@ -320,6 +320,7 @@
       <ProgramDatabaseFile>.\Client_Release/SageTVClient.pdb</ProgramDatabaseFile>
       <SubSystem>Windows</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
+      <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Service Release|Win32'">
@@ -361,6 +362,7 @@
       <ProgramDatabaseFile>.\Service_Release/SageTVService.pdb</ProgramDatabaseFile>
       <SubSystem>Windows</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
+      <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Recorder Debug|Win32'">
@@ -442,6 +444,7 @@
       <ProgramDatabaseFile>.\Release/SageTV.pdb</ProgramDatabaseFile>
       <SubSystem>Windows</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
+      <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Service Debug|Win32'">

--- a/native/exe/ServiceControlLaunch/ServiceControlLaunch.vcxproj
+++ b/native/exe/ServiceControlLaunch/ServiceControlLaunch.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -147,6 +147,7 @@
       <ProgramDatabaseFile>.\Release/SageTVServiceControl.pdb</ProgramDatabaseFile>
       <SubSystem>Windows</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
+      <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Lite Service Release|Win32'">


### PR DESCRIPTION
Manifests now force Administrator properly.  Version numbers set to 9.0.4.220 as well.