### PR TITLE
Default wizard/revert_stv_on_upgrade to false if it is not already set

### DIFF
--- a/java/sage/UIManager.java
+++ b/java/sage/UIManager.java
@@ -1161,7 +1161,7 @@ public class UIManager implements Runnable, UIClient
         }
         // Don't reset MVP/PS UIs on upgrade of a server or they'll keep getting reset every time they connect
         // until the server is restarted!
-        if (!Sage.EMBEDDED && (fileStr == null || (Sage.getBoolean("wizard/revert_stv_on_upgrade", true) && ((SageTV.upgrade &&
+        if (!Sage.EMBEDDED && (fileStr == null || (Sage.getBoolean("wizard/revert_stv_on_upgrade", false) && ((SageTV.upgrade &&
             getUIClientType() != UIClient.REMOTE_UI) || (getUIClientType() == UIClient.REMOTE_UI && !SAGE.equals(get("ui/last_version", "")))))))
         {
           fileStr = new File(System.getProperty("user.dir"),


### PR DESCRIPTION
As per [discussion on the forums](http://forums.sagetv.com/forums/showthread.php?p=584289&postcount=246) 

Changed this property's default value (wizard/revert_stv_on_upgrade) to false so upgrades do not force the STV to be changed from a custom one to the default one.  Users can still change the value of this property (wizard/revert_stv_on_upgrade) to true if they are having any issues with an STV that won't launch