### PR TITLE
Fix Freetype font UnsatisfiedLinkError in Linux and cleanup/fix Windows MinGW DLL build

### DIFF
--- a/native/crosslibs/Freetype/Makefile.win
+++ b/native/crosslibs/Freetype/Makefile.win
@@ -2,7 +2,9 @@ CC=gcc
 #CC=mipsel-unknown-linux-gnu-gcc
 #CFLAGS = -c -fPIC -I/usr/local/j2sdk/include/ -I/usr/local/j2sdk/include/linux -D_FILE_OFFSET_BITS=64 -I/video/sagecrossbuild/include/freetype2/ -I/video/sagecrossbuild/include/
 #CFLAGS = -c -fPIC -I/usr/local/j2sdk/include/ -I/usr/local/j2sdk/include/linux -D_FILE_OFFSET_BITS=64 -I/usr/include/freetype2/
-CFLAGS = -c -O -D_JNI_IMPLEMENTATION -IC:\\jdk1.4\\include -IC:\\jdk1.4\\include\\win32 -IC:\\msys\\1.0\\home\\Narflex\\freetype-2.1.10\\include
+#CFLAGS = -c -O -D_JNI_IMPLEMENTATION -IC:\\jdk1.4\\include -IC:\\jdk1.4\\include\\win32 -IC:\\msys\\1.0\\home\\Narflex\\freetype-2.1.10\\include
+CFLAGS = -c -O -D_JNI_IMPLEMENTATION -IC:\\Program\ Files\ \(x86\)\\Java\\jdk1.8.0_72\\include -IC:\\Program\ Files\ \(x86\)\\Java\\jdk1.8.0_72\\include\\win32 -IC:\\temp\\sagetv\\stage\\include -IC:\\temp\\sagetv\\stage\\include\\freetype2
+LIBPATH = C:\\temp\\sagetv\\stage\\lib
 BINDIR=/usr/local/bin
 
 OBJFILES=sage_FreetypeFont.o
@@ -10,7 +12,7 @@ OBJFILES=sage_FreetypeFont.o
 FreetypeFontJNI.dll: $(OBJFILES)
 #	$(CC) -shared -W1 -o libFreetypeFontJNI.so $(OBJFILES) -L/video/crosstool-8634-2/crosstool/gcc-4.2-20070307-glibc-2.5/mipsel-unknown-linux-gnu/lib -lfreetype
 #	$(CC) -shared -W1 -o libFreetypeFontJNI.so $(OBJFILES) -L/video/sagecrosslib/lib -lfreetype
-	$(CC) -shared -W1 -o FreetypeFontJNI.dll $(OBJFILES) -lfreetype -lz
+	$(CC) -Wl,--kill-at -shared -static -L$(LIBPATH) -o FreetypeFontJNI.dll $(OBJFILES) -lfreetype -lz
 
 clean:
 	rm -f *.o FreetypeFontJNI.dll *.c~ *.h~

--- a/native/crosslibs/Freetype/sage_FreetypeFont.c
+++ b/native/crosslibs/Freetype/sage_FreetypeFont.c
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <stdint.h>
 #include <ft2build.h>
 #include FT_FREETYPE_H
 #include "sage_FreetypeFont.h"
@@ -58,7 +59,7 @@ void sysOutPrint(JNIEnv* env, const char* cstr, ...)
  * Method:    loadFreetypeLib0
  * Signature: ()J
  */
-JNIEXPORT jlong JNICALL _Java_sage_FreetypeFont_loadFreetypeLib0
+JNIEXPORT jlong JNICALL Java_sage_FreetypeFont_loadFreetypeLib0
   (JNIEnv *env, jclass jc)
 {
 	FT_Library library;
@@ -68,7 +69,7 @@ JNIEXPORT jlong JNICALL _Java_sage_FreetypeFont_loadFreetypeLib0
 		sysOutPrint(env, "Error loading FreeType of %d\n", error);
 		return 0;
 	}
- 	return (jlong) library;
+ 	return (jlong)(intptr_t) library;
 }
 
 /*
@@ -76,10 +77,10 @@ JNIEXPORT jlong JNICALL _Java_sage_FreetypeFont_loadFreetypeLib0
  * Method:    closeFreetypeLib0
  * Signature: (J)Z
  */
-JNIEXPORT jboolean JNICALL _Java_sage_FreetypeFont_closeFreetypeLib0
+JNIEXPORT jboolean JNICALL Java_sage_FreetypeFont_closeFreetypeLib0
   (JNIEnv *env, jclass jc, jlong ptr)
 {
-	FT_Library library = (FT_Library) ptr;
+	FT_Library library = (FT_Library)(intptr_t) ptr;
 	if (library)
 	{
 		if (FT_Done_FreeType(library))
@@ -95,10 +96,10 @@ JNIEXPORT jboolean JNICALL _Java_sage_FreetypeFont_closeFreetypeLib0
  * Method:    closeFontFace0
  * Signature: (J)Z
  */
-JNIEXPORT jboolean JNICALL _Java_sage_FreetypeFont_closeFontFace0
+JNIEXPORT jboolean JNICALL Java_sage_FreetypeFont_closeFontFace0
   (JNIEnv *env, jobject jo, jlong fontPtr)
 {
-	FTDataStruct* fontData = (FTDataStruct*) fontPtr;
+	FTDataStruct* fontData = (FTDataStruct*)(intptr_t) fontPtr;
 	// NOTE: WE CAN ONLY CLOSE THE SIZE SINCE OTHERS MIGHT STILL BE USING THE FACE!!!!
 	// THIS LEAKS MEMORY IF YOU THINK IT'LL CLOSE THE FONT FACE!!!!!
 	// THIS LEAKS MEMORY IF YOU THINK IT'LL CLOSE THE FONT FACE!!!!!
@@ -113,12 +114,12 @@ JNIEXPORT jboolean JNICALL _Java_sage_FreetypeFont_closeFontFace0
  * Method:    loadFontFace0
  * Signature: (JLjava/lang/String;I)J
  */
-JNIEXPORT jlong JNICALL _Java_sage_FreetypeFont_loadFontFace0
+JNIEXPORT jlong JNICALL Java_sage_FreetypeFont_loadFontFace0
   (JNIEnv *env, jobject jo, jlong ftLibPtr, jstring jstr, jint ptSize, jint style)
 {
 
 	FT_Face face;
-	FT_Library library = (FT_Library) ftLibPtr;
+	FT_Library library = (FT_Library)(intptr_t) ftLibPtr;
 	const char* cstr = (*env)->GetStringUTFChars(env, jstr, NULL);
 	int error = FT_New_Face(library, cstr, 0, &face);
 
@@ -162,7 +163,7 @@ JNIEXPORT jlong JNICALL _Java_sage_FreetypeFont_loadFontFace0
 	}
 	
     	
-	return (jlong) rv;
+	return (jlong)(intptr_t) rv;
 }
 
 
@@ -171,10 +172,10 @@ JNIEXPORT jlong JNICALL _Java_sage_FreetypeFont_loadFontFace0
  * Method:    deriveFontFace0
  * Signature: (JI)J
  */
-JNIEXPORT jlong JNICALL _Java_sage_FreetypeFont_deriveFontFace0
+JNIEXPORT jlong JNICALL Java_sage_FreetypeFont_deriveFontFace0
   (JNIEnv *env, jobject jo, jlong fontPtr, jint ptSize, jint style)
 {
-	FTDataStruct* fontData = (FTDataStruct*) fontPtr;
+	FTDataStruct* fontData = (FTDataStruct*)(intptr_t) fontPtr;
 	FT_Size newSize;
 	int error = FT_New_Size(fontData->facePtr, &newSize);
 	if (error)
@@ -215,7 +216,7 @@ JNIEXPORT jlong JNICALL _Java_sage_FreetypeFont_deriveFontFace0
 			rv->style = rv->style | FT_STYLE_FLAG_ITALIC;
 		}
 	}
-	return rv;
+	return (jlong)(intptr_t) rv;
 }
 
 /*
@@ -223,11 +224,11 @@ JNIEXPORT jlong JNICALL _Java_sage_FreetypeFont_deriveFontFace0
  * Method:    getGlyphForChar0
  * Signature: (JC)I
  */
-JNIEXPORT jint JNICALL _Java_sage_FreetypeFont_getGlyphForChar0
+JNIEXPORT jint JNICALL Java_sage_FreetypeFont_getGlyphForChar0
   (JNIEnv *env, jobject jo, jlong fontPtr, jchar c)
 {
 	//FT_Face face = (FT_Face) facePtr;
-	FTDataStruct* fontData = (FTDataStruct*) fontPtr;
+	FTDataStruct* fontData = (FTDataStruct*)(intptr_t) fontPtr;
 	return FT_Get_Char_Index(fontData->facePtr, c);
 }
 
@@ -236,11 +237,11 @@ JNIEXPORT jint JNICALL _Java_sage_FreetypeFont_getGlyphForChar0
  * Method:    loadGlyph0
  * Signature: (JI)V
  */
-JNIEXPORT void JNICALL _Java_sage_FreetypeFont_loadGlyph0
+JNIEXPORT void JNICALL Java_sage_FreetypeFont_loadGlyph0
   (JNIEnv *env, jobject jo, jlong fontPtr, jint glyphCode)
 {
 	//FT_Face face = (FT_Face) facePtr;
-	FTDataStruct* fontData = (FTDataStruct*) fontPtr;
+	FTDataStruct* fontData = (FTDataStruct*)(intptr_t) fontPtr;
 	FT_Activate_Size(fontData->sizePtr);
 	int error = FT_Load_Glyph(fontData->facePtr, glyphCode, FT_LOAD_DEFAULT);
 	if ((fontData->style & FT_STYLE_FLAG_BOLD) != 0)
@@ -313,10 +314,10 @@ FT_Pos dy = dx;
  * Method:    renderGlyph0
  * Signature: (JLjava/awt/image/BufferedImage;II)I
  */
-JNIEXPORT jint JNICALL _Java_sage_FreetypeFont_renderGlyph0
+JNIEXPORT jint JNICALL Java_sage_FreetypeFont_renderGlyph0
   (JNIEnv *env, jobject jo, jlong fontPtr, jobject buffImage, jint imageX, jint imageY)
 {
-	FTDataStruct* fontData = (FTDataStruct*) fontPtr;
+	FTDataStruct* fontData = (FTDataStruct*)(intptr_t) fontPtr;
 	FT_Face face = fontData->facePtr;
 	FT_Activate_Size(fontData->sizePtr);
 	int error = FT_Render_Glyph(face->glyph, ft_render_mode_normal);
@@ -361,7 +362,7 @@ JNIEXPORT jint JNICALL _Java_sage_FreetypeFont_renderGlyph0
  * Method:    renderGlyphRaw0
  * Signature: (JLsage/media/image/RawImage;IIII)Lsage/media/image/RawImage;
  */
-JNIEXPORT jobject JNICALL _Java_sage_FreetypeFont_renderGlyphRaw0
+JNIEXPORT jobject JNICALL Java_sage_FreetypeFont_renderGlyphRaw0
   (JNIEnv *env, jobject jo, jlong fontPtr, jobject inRawImage, jint rawWidth, jint rawHeight, jint imageX, jint imageY)
 {
 	static jclass rawImageClass = 0;
@@ -418,7 +419,7 @@ JNIEXPORT jobject JNICALL _Java_sage_FreetypeFont_renderGlyphRaw0
 		myImageData = (unsigned char*) (*env)->GetDirectBufferAddress(env, bb);
 	}
 
-	FTDataStruct* fontData = (FTDataStruct*) fontPtr;
+	FTDataStruct* fontData = (FTDataStruct*)(intptr_t) fontPtr;
 	FT_Face face = fontData->facePtr;
 	FT_Activate_Size(fontData->sizePtr);
 	// Render the glyph to a FT buffer
@@ -459,10 +460,10 @@ JNIEXPORT jobject JNICALL _Java_sage_FreetypeFont_renderGlyphRaw0
  * Method:    getNumGlyphs0
  * Signature: (J)I
  */
-JNIEXPORT jint JNICALL _Java_sage_FreetypeFont_getNumGlyphs0
+JNIEXPORT jint JNICALL Java_sage_FreetypeFont_getNumGlyphs0
   (JNIEnv *env, jobject jo, jlong fontPtr)
 {
-	FTDataStruct* fontData = (FTDataStruct*) fontPtr;
+	FTDataStruct* fontData = (FTDataStruct*)(intptr_t) fontPtr;
 	return fontData->facePtr->num_glyphs;
 }
 /*
@@ -470,10 +471,10 @@ JNIEXPORT jint JNICALL _Java_sage_FreetypeFont_getNumGlyphs0
  * Method:    getGlyphWidth0
  * Signature: (J)I
  */
-JNIEXPORT jint JNICALL _Java_sage_FreetypeFont_getGlyphWidth0
+JNIEXPORT jint JNICALL Java_sage_FreetypeFont_getGlyphWidth0
   (JNIEnv *env, jobject jo, jlong fontPtr)
 {
-	FTDataStruct* fontData = (FTDataStruct*) fontPtr;
+	FTDataStruct* fontData = (FTDataStruct*)(intptr_t) fontPtr;
 	return fontData->facePtr->glyph->metrics.width;
 }
 
@@ -482,10 +483,10 @@ JNIEXPORT jint JNICALL _Java_sage_FreetypeFont_getGlyphWidth0
  * Method:    getGlyphHeight0
  * Signature: (J)I
  */
-JNIEXPORT jint JNICALL _Java_sage_FreetypeFont_getGlyphHeight0
+JNIEXPORT jint JNICALL Java_sage_FreetypeFont_getGlyphHeight0
   (JNIEnv *env, jobject jo, jlong fontPtr)
 {
-	FTDataStruct* fontData = (FTDataStruct*) fontPtr;
+	FTDataStruct* fontData = (FTDataStruct*)(intptr_t) fontPtr;
 	return fontData->facePtr->glyph->metrics.height;
 }
 
@@ -494,10 +495,10 @@ JNIEXPORT jint JNICALL _Java_sage_FreetypeFont_getGlyphHeight0
  * Method:    getGlyphBearingX0
  * Signature: (J)I
  */
-JNIEXPORT jint JNICALL _Java_sage_FreetypeFont_getGlyphBearingX0
+JNIEXPORT jint JNICALL Java_sage_FreetypeFont_getGlyphBearingX0
   (JNIEnv *env, jobject jo, jlong fontPtr)
 {
-	FTDataStruct* fontData = (FTDataStruct*) fontPtr;
+	FTDataStruct* fontData = (FTDataStruct*)(intptr_t) fontPtr;
 	return fontData->facePtr->glyph->metrics.horiBearingX;
 }
 
@@ -506,10 +507,10 @@ JNIEXPORT jint JNICALL _Java_sage_FreetypeFont_getGlyphBearingX0
  * Method:    getGlyphBearingY0
  * Signature: (J)I
  */
-JNIEXPORT jint JNICALL _Java_sage_FreetypeFont_getGlyphBearingY0
+JNIEXPORT jint JNICALL Java_sage_FreetypeFont_getGlyphBearingY0
   (JNIEnv *env, jobject jo, jlong fontPtr)
 {
-	FTDataStruct* fontData = (FTDataStruct*) fontPtr;
+	FTDataStruct* fontData = (FTDataStruct*)(intptr_t) fontPtr;
 	return fontData->facePtr->glyph->metrics.horiBearingY;
 }
 
@@ -518,10 +519,10 @@ JNIEXPORT jint JNICALL _Java_sage_FreetypeFont_getGlyphBearingY0
  * Method:    getGlyphAdvance0
  * Signature: (J)I
  */
-JNIEXPORT jint JNICALL _Java_sage_FreetypeFont_getGlyphAdvance0
+JNIEXPORT jint JNICALL Java_sage_FreetypeFont_getGlyphAdvance0
   (JNIEnv *env, jobject jo, jlong fontPtr)
 {
-	FTDataStruct* fontData = (FTDataStruct*) fontPtr;
+	FTDataStruct* fontData = (FTDataStruct*)(intptr_t) fontPtr;
 	return fontData->facePtr->glyph->advance.x;
 }
 
@@ -530,10 +531,10 @@ JNIEXPORT jint JNICALL _Java_sage_FreetypeFont_getGlyphAdvance0
  * Method:    getFontHeight0
  * Signature: (J)I
  */
-JNIEXPORT jint JNICALL _Java_sage_FreetypeFont_getFontHeight0
+JNIEXPORT jint JNICALL Java_sage_FreetypeFont_getFontHeight0
   (JNIEnv *env, jobject jo, jlong fontPtr)
 {
-	FTDataStruct* fontData = (FTDataStruct*) fontPtr;
+	FTDataStruct* fontData = (FTDataStruct*)(intptr_t) fontPtr;
 	return fontData->sizePtr->metrics.height;
 }
 
@@ -542,10 +543,10 @@ JNIEXPORT jint JNICALL _Java_sage_FreetypeFont_getFontHeight0
  * Method:    getFontAscent0
  * Signature: (J)I
  */
-JNIEXPORT jint JNICALL _Java_sage_FreetypeFont_getFontAscent0
+JNIEXPORT jint JNICALL Java_sage_FreetypeFont_getFontAscent0
   (JNIEnv *env, jobject jo, jlong fontPtr)
 {
-	FTDataStruct* fontData = (FTDataStruct*) fontPtr;
+	FTDataStruct* fontData = (FTDataStruct*)(intptr_t) fontPtr;
 	return fontData->sizePtr->metrics.ascender;
 }
 
@@ -554,9 +555,9 @@ JNIEXPORT jint JNICALL _Java_sage_FreetypeFont_getFontAscent0
  * Method:    getFontDescent0
  * Signature: (J)I
  */
-JNIEXPORT jint JNICALL _Java_sage_FreetypeFont_getFontDescent0
+JNIEXPORT jint JNICALL Java_sage_FreetypeFont_getFontDescent0
   (JNIEnv *env, jobject jo, jlong fontPtr)
 {
-	FTDataStruct* fontData = (FTDataStruct*) fontPtr;
+	FTDataStruct* fontData = (FTDataStruct*)(intptr_t) fontPtr;
 	return fontData->sizePtr->metrics.descender;
 }

--- a/native/crosslibs/Freetype/sage_FreetypeFont.h
+++ b/native/crosslibs/Freetype/sage_FreetypeFont.h
@@ -20,7 +20,7 @@ extern "C" {
  * Method:    loadFreetypeLib0
  * Signature: ()J
  */
-JNIEXPORT jlong JNICALL _Java_sage_FreetypeFont_loadFreetypeLib0
+JNIEXPORT jlong JNICALL Java_sage_FreetypeFont_loadFreetypeLib0
   (JNIEnv *, jclass);
 
 /*
@@ -28,7 +28,7 @@ JNIEXPORT jlong JNICALL _Java_sage_FreetypeFont_loadFreetypeLib0
  * Method:    closeFreetypeLib0
  * Signature: (J)Z
  */
-JNIEXPORT jboolean JNICALL _Java_sage_FreetypeFont_closeFreetypeLib0
+JNIEXPORT jboolean JNICALL Java_sage_FreetypeFont_closeFreetypeLib0
   (JNIEnv *, jclass, jlong);
 
 /*
@@ -36,7 +36,7 @@ JNIEXPORT jboolean JNICALL _Java_sage_FreetypeFont_closeFreetypeLib0
  * Method:    closeFontFace0
  * Signature: (J)Z
  */
-JNIEXPORT jboolean JNICALL _Java_sage_FreetypeFont_closeFontFace0
+JNIEXPORT jboolean JNICALL Java_sage_FreetypeFont_closeFontFace0
   (JNIEnv *, jobject, jlong);
 
 /*
@@ -44,7 +44,7 @@ JNIEXPORT jboolean JNICALL _Java_sage_FreetypeFont_closeFontFace0
  * Method:    loadFontFace0
  * Signature: (JLjava/lang/String;II)J
  */
-JNIEXPORT jlong JNICALL _Java_sage_FreetypeFont_loadFontFace0
+JNIEXPORT jlong JNICALL Java_sage_FreetypeFont_loadFontFace0
   (JNIEnv *, jobject, jlong, jstring, jint, jint);
 
 /*
@@ -52,7 +52,7 @@ JNIEXPORT jlong JNICALL _Java_sage_FreetypeFont_loadFontFace0
  * Method:    deriveFontFace0
  * Signature: (JII)J
  */
-JNIEXPORT jlong JNICALL _Java_sage_FreetypeFont_deriveFontFace0
+JNIEXPORT jlong JNICALL Java_sage_FreetypeFont_deriveFontFace0
   (JNIEnv *, jobject, jlong, jint, jint);
 
 /*
@@ -60,7 +60,7 @@ JNIEXPORT jlong JNICALL _Java_sage_FreetypeFont_deriveFontFace0
  * Method:    getGlyphForChar0
  * Signature: (JC)I
  */
-JNIEXPORT jint JNICALL _Java_sage_FreetypeFont_getGlyphForChar0
+JNIEXPORT jint JNICALL Java_sage_FreetypeFont_getGlyphForChar0
   (JNIEnv *, jobject, jlong, jchar);
 
 /*
@@ -68,7 +68,7 @@ JNIEXPORT jint JNICALL _Java_sage_FreetypeFont_getGlyphForChar0
  * Method:    loadGlyph0
  * Signature: (JI)V
  */
-JNIEXPORT void JNICALL _Java_sage_FreetypeFont_loadGlyph0
+JNIEXPORT void JNICALL Java_sage_FreetypeFont_loadGlyph0
   (JNIEnv *, jobject, jlong, jint);
 
 /*
@@ -76,7 +76,7 @@ JNIEXPORT void JNICALL _Java_sage_FreetypeFont_loadGlyph0
  * Method:    renderGlyph0
  * Signature: (JLjava/awt/image/BufferedImage;II)I
  */
-JNIEXPORT jint JNICALL _Java_sage_FreetypeFont_renderGlyph0
+JNIEXPORT jint JNICALL Java_sage_FreetypeFont_renderGlyph0
   (JNIEnv *, jobject, jlong, jobject, jint, jint);
 
 /*
@@ -84,7 +84,7 @@ JNIEXPORT jint JNICALL _Java_sage_FreetypeFont_renderGlyph0
  * Method:    renderGlyphRaw0
  * Signature: (JLsage/media/image/RawImage;IIII)Lsage/media/image/RawImage;
  */
-JNIEXPORT jobject JNICALL _Java_sage_FreetypeFont_renderGlyphRaw0
+JNIEXPORT jobject JNICALL Java_sage_FreetypeFont_renderGlyphRaw0
   (JNIEnv *, jobject, jlong, jobject, jint, jint, jint, jint);
 
 /*
@@ -92,7 +92,7 @@ JNIEXPORT jobject JNICALL _Java_sage_FreetypeFont_renderGlyphRaw0
  * Method:    getNumGlyphs0
  * Signature: (J)I
  */
-JNIEXPORT jint JNICALL _Java_sage_FreetypeFont_getNumGlyphs0
+JNIEXPORT jint JNICALL Java_sage_FreetypeFont_getNumGlyphs0
   (JNIEnv *, jobject, jlong);
 
 /*
@@ -100,7 +100,7 @@ JNIEXPORT jint JNICALL _Java_sage_FreetypeFont_getNumGlyphs0
  * Method:    getGlyphWidth0
  * Signature: (J)I
  */
-JNIEXPORT jint JNICALL _Java_sage_FreetypeFont_getGlyphWidth0
+JNIEXPORT jint JNICALL Java_sage_FreetypeFont_getGlyphWidth0
   (JNIEnv *, jobject, jlong);
 
 /*
@@ -108,7 +108,7 @@ JNIEXPORT jint JNICALL _Java_sage_FreetypeFont_getGlyphWidth0
  * Method:    getGlyphHeight0
  * Signature: (J)I
  */
-JNIEXPORT jint JNICALL _Java_sage_FreetypeFont_getGlyphHeight0
+JNIEXPORT jint JNICALL Java_sage_FreetypeFont_getGlyphHeight0
   (JNIEnv *, jobject, jlong);
 
 /*
@@ -116,7 +116,7 @@ JNIEXPORT jint JNICALL _Java_sage_FreetypeFont_getGlyphHeight0
  * Method:    getGlyphBearingX0
  * Signature: (J)I
  */
-JNIEXPORT jint JNICALL _Java_sage_FreetypeFont_getGlyphBearingX0
+JNIEXPORT jint JNICALL Java_sage_FreetypeFont_getGlyphBearingX0
   (JNIEnv *, jobject, jlong);
 
 /*
@@ -124,7 +124,7 @@ JNIEXPORT jint JNICALL _Java_sage_FreetypeFont_getGlyphBearingX0
  * Method:    getGlyphBearingY0
  * Signature: (J)I
  */
-JNIEXPORT jint JNICALL _Java_sage_FreetypeFont_getGlyphBearingY0
+JNIEXPORT jint JNICALL Java_sage_FreetypeFont_getGlyphBearingY0
   (JNIEnv *, jobject, jlong);
 
 /*
@@ -132,7 +132,7 @@ JNIEXPORT jint JNICALL _Java_sage_FreetypeFont_getGlyphBearingY0
  * Method:    getGlyphAdvance0
  * Signature: (J)I
  */
-JNIEXPORT jint JNICALL _Java_sage_FreetypeFont_getGlyphAdvance0
+JNIEXPORT jint JNICALL Java_sage_FreetypeFont_getGlyphAdvance0
   (JNIEnv *, jobject, jlong);
 
 /*
@@ -140,7 +140,7 @@ JNIEXPORT jint JNICALL _Java_sage_FreetypeFont_getGlyphAdvance0
  * Method:    getFontHeight0
  * Signature: (J)I
  */
-JNIEXPORT jint JNICALL _Java_sage_FreetypeFont_getFontHeight0
+JNIEXPORT jint JNICALL Java_sage_FreetypeFont_getFontHeight0
   (JNIEnv *, jobject, jlong);
 
 /*
@@ -148,7 +148,7 @@ JNIEXPORT jint JNICALL _Java_sage_FreetypeFont_getFontHeight0
  * Method:    getFontAscent0
  * Signature: (J)I
  */
-JNIEXPORT jint JNICALL _Java_sage_FreetypeFont_getFontAscent0
+JNIEXPORT jint JNICALL Java_sage_FreetypeFont_getFontAscent0
   (JNIEnv *, jobject, jlong);
 
 /*
@@ -156,7 +156,7 @@ JNIEXPORT jint JNICALL _Java_sage_FreetypeFont_getFontAscent0
  * Method:    getFontDescent0
  * Signature: (J)I
  */
-JNIEXPORT jint JNICALL _Java_sage_FreetypeFont_getFontDescent0
+JNIEXPORT jint JNICALL Java_sage_FreetypeFont_getFontDescent0
   (JNIEnv *, jobject, jlong);
 
 #ifdef __cplusplus


### PR DESCRIPTION
This request fixes the Freetype font errors when making JNI calls to the native library on Linux:

`Tue 2/2 0:26:10.529 [MiniUIServerConnection@1decba4d] Error loading Freetype Font; trying to load Java font instead; error=java.lang.UnsatisfiedLinkError: sage.FreetypeFont.loadFreetypeLib0()J`

The function names were originally prefixed/hard-coded with an underscore to make them work in the Windows JVM but this caused the calls to fail in Linux. The solution is to remove the underscores which fixes the Linux issue, and then add the "-Wl,--kill-at" linker option for Windows MinGW so the DLL exports the undecorated symbol names.

After doing some research, I learned that the Windows JVM JNI call will try two methods when calling a native function: _functionName@x and functionName, but the MinGW-generated DLL by default exports the symbols as functionName@x.  The kill-at option removes the trailing "@x" and allows the Windows JNI calls to work.

I also cleaned up a bunch of compiler warnings on 32-bit related to pointers being cast to jlong, and I added the -static linker option for Windows because the FreetypeFontJNI.dll distributed with V7 appears to be a static library.

It now builds clean on Linux 64-bit and Windows 32-bit (with MinGW).  I've tested the resulting libraries with SageTV V9 on Linux 64-bit and 7.1.9 on Windows XP and the JNI calls work correctly on both platforms.

The Makefile.win may still need some cleanup...it appeared to be customized for an old system of Jeff's so I updated the CFLAGS and added LIBPATH so I could run the build on my Windows system.