### PR TITLE
Manifest changes to remove the need for elevation from server/client/service

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -24,3 +24,4 @@ Raymond Chi <raychi@gmail.com>
 Joshua Lewis <josh@joshandmonique.com>
 Martin Weber Nissle <webernissle@gmail.com>
 Chris Danser <chris.danser@gmail.com>
+Ken Birch <usjusjoken@gmail.com>

--- a/native/exe/SageLauncher/SageLauncher.vcxproj
+++ b/native/exe/SageLauncher/SageLauncher.vcxproj
@@ -320,7 +320,7 @@
       <ProgramDatabaseFile>.\Client_Release/SageTVClient.pdb</ProgramDatabaseFile>
       <SubSystem>Windows</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
-      <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
+      <UACExecutionLevel>AsInvoker</UACExecutionLevel>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Service Release|Win32'">
@@ -362,7 +362,7 @@
       <ProgramDatabaseFile>.\Service_Release/SageTVService.pdb</ProgramDatabaseFile>
       <SubSystem>Windows</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
-      <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
+      <UACExecutionLevel>AsInvoker</UACExecutionLevel>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Recorder Debug|Win32'">
@@ -444,7 +444,7 @@
       <ProgramDatabaseFile>.\Release/SageTV.pdb</ProgramDatabaseFile>
       <SubSystem>Windows</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
-      <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
+      <UACExecutionLevel>AsInvoker</UACExecutionLevel>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Service Debug|Win32'">


### PR DESCRIPTION
The installer is now taking a different approach for the registry permissions and no longer needs this elevation.

Added myself into CONTRIBUTORS