### PR TITLE
FreeType fonts rendering to a smaller size with FT 2.4.0 and higher

### DIFF
--- a/native/crosslibs/Freetype/sage_FreetypeFont.c
+++ b/native/crosslibs/Freetype/sage_FreetypeFont.c
@@ -243,7 +243,7 @@ JNIEXPORT void JNICALL Java_sage_FreetypeFont_loadGlyph0
 	//FT_Face face = (FT_Face) facePtr;
 	FTDataStruct* fontData = (FTDataStruct*)(intptr_t) fontPtr;
 	FT_Activate_Size(fontData->sizePtr);
-	int error = FT_Load_Glyph(fontData->facePtr, glyphCode, FT_LOAD_DEFAULT);
+	int error = FT_Load_Glyph(fontData->facePtr, glyphCode, FT_LOAD_FORCE_AUTOHINT);
 	if ((fontData->style & FT_STYLE_FLAG_BOLD) != 0)
 	{
 		// Apply bold effect


### PR DESCRIPTION
Starting with FreeType 2.4, the new Bytecode Interpreter renders many of the commonly used UI fonts slightly smaller than the older versions.  This issue is noticeable when comparing a Windows SageTV UI to a Linux SageTV UI (at least on an extender), because most Linux distributions since 2010/2011 have FT 2.4 or higher but the FreeType used to build the SageTV static FreetypeFontJNI.dll appears to be 2.1.10.

This fix changes the rendering so that SageTV generates the same font sizes with the newer FT versions as it did with the older FT version that is used in the V7/V9 Windows distribution, resulting in the same UI "look" on both platforms.  This will also prevent the font sizes from being reduced if the Windows FreetypeFontJNI.dll is rebuilt in the future using a newer FreeType.

I tested this fix on both platforms and with many FT versions from 2.1.10 through the latest 2.6.3 on Windows and Linux and the resulting fonts look the same in all cases, and in Linux they now match the look of the Windows SageTV UI.

See the following forum thread for more details: [http://forums.sagetv.com/forums/showthread.php?t=62988](url)

To get the full effect of this fix on an existing system with FT 2.4.0 or higher, the files in the SageTV fontcache directory will need to be deleted after applying the fix so the font cache files can be re-created with the new rendering.