### PR TITLE
Allow Ministry (Transcoding queue) to keep Server awake.

### DIFF
--- a/java/sage/Ministry.java
+++ b/java/sage/Ministry.java
@@ -825,6 +825,15 @@ public class Ministry implements Runnable
       return true;
   }
 
+  public boolean requiresPower()
+  {
+    // This is true if there's any transcode jobs are in the queue
+    synchronized (this)
+    {
+    	return (getTranscodeJobIDs().length > 0) ? true : false ;
+    }
+  }
+  
   private Object lock = new Object();
   private java.util.Vector waitingForConversion = new java.util.Vector();
   private java.util.Vector converting = new java.util.Vector();

--- a/java/sage/NetworkEncoderManager.java
+++ b/java/sage/NetworkEncoderManager.java
@@ -64,7 +64,7 @@ public class NetworkEncoderManager implements CaptureDeviceManager
       }
     }
 
-    if (Sage.getBoolean("network_encoder_discovery", false))
+    if (Sage.getBoolean("network_encoder_discovery", true))
     {
       // Now do the broadcast discovery of new encoding servers on the network
       if (Sage.DBG) System.out.println("Doing broadcast discovery of new encoding servers on the network...");

--- a/java/sage/ServerPowerManagement.java
+++ b/java/sage/ServerPowerManagement.java
@@ -56,6 +56,8 @@ public class ServerPowerManagement extends PowerManagement
     {
       if (Seeker.getInstance().requiresPower())
         return SYSTEM_POWER;
+      if (Ministry.getInstance().requiresPower())
+    	return SYSTEM_POWER;
       // Check for any streaming clients or non-locally connected SageTV Clients
       MediaServer ms = SageTV.getMediaServer();
       if ((ms != null && ms.areClientsConnected()) || NetworkClient.areNonLocalClientsConnected())


### PR DESCRIPTION
Added a function requiresPower() to Ministry, and added a check to ServerPowerManagement to check it.  This functionality clones how ServerPowerManagement checks Seeker for activity.