### PR TITLE
The transition (SWITCH) point for MPEG2-PS would sometimes never be found because of signed bytes in Java.

### DIFF
--- a/java/sage/MediaServerRemuxer.java
+++ b/java/sage/MediaServerRemuxer.java
@@ -604,7 +604,7 @@ public class MediaServerRemuxer
         if (data.get(i) == 0x00 &&
             data.get(i + 1) == 0x00 &&
             data.get(i + 2) == 0x01 &&
-            data.get(i + 3) == 0xBA)
+            (data.get(i + 3) & 0xFF) == 0xBA)
         {
           psStart = i;
 


### PR DESCRIPTION
I missed this one since my test cases actually passed without this modification, but just the other day I caught a few transition that timed out because over 8MB of data was processed without finding a transition point. The root of the problem is signed bytes. This masks the bytes so we are comparing the correct "unsigned" value.