### PR TITLE
Unit Test Changes

### DIFF
--- a/java/sage/CVMUtils.java
+++ b/java/sage/CVMUtils.java
@@ -27,7 +27,7 @@ public class CVMUtils
     {
       try
       {
-        System.loadLibrary("CVMUtils");
+        sage.Native.loadLibrary("CVMUtils");
       }
       catch (Throwable t)
       {

--- a/java/sage/DShowCaptureDevice.java
+++ b/java/sage/DShowCaptureDevice.java
@@ -49,7 +49,7 @@ public class DShowCaptureDevice extends CaptureDevice
   {
     // This library is also used for getting a list of the dshow filters, so we need it for players as well
     if (Sage.WINDOWS_OS)
-      System.loadLibrary("DShowCapture");
+      sage.Native.loadLibrary("DShowCapture");
   }
   public DShowCaptureDevice()
   {

--- a/java/sage/DShowCaptureManager.java
+++ b/java/sage/DShowCaptureManager.java
@@ -56,7 +56,7 @@ public class DShowCaptureManager implements CaptureDeviceManager
 
   public DShowCaptureManager()
   {
-    System.loadLibrary("DShowCapture");
+    sage.Native.loadLibrary("DShowCapture");
 
     prefs = MMC.MMC_KEY + '/';
     mmc = MMC.getInstance();

--- a/java/sage/DShowMediaPlayer.java
+++ b/java/sage/DShowMediaPlayer.java
@@ -80,7 +80,7 @@ public class DShowMediaPlayer implements DVDMediaPlayer
   {
     if (Sage.WINDOWS_OS)
     {
-      System.loadLibrary("DShowPlayer");
+      sage.Native.loadLibrary("DShowPlayer");
       java.util.ArrayList videoFilters = new java.util.ArrayList();
       java.util.ArrayList audioFilters = new java.util.ArrayList();
       audioFilters.add("Cyberlink Audio Decoder");

--- a/java/sage/DShowSharedLiveMediaPlayer.java
+++ b/java/sage/DShowSharedLiveMediaPlayer.java
@@ -21,7 +21,7 @@ public class DShowSharedLiveMediaPlayer implements MediaPlayer
   {
     if (Sage.WINDOWS_OS)
     {
-      System.loadLibrary("DShowPlayer");
+      sage.Native.loadLibrary("DShowPlayer");
     }
   }
 

--- a/java/sage/DShowTranscodeJob.java
+++ b/java/sage/DShowTranscodeJob.java
@@ -25,7 +25,7 @@ public class DShowTranscodeJob extends TranscodeJob implements Runnable
   {
     if (Sage.WINDOWS_OS && SageConstants.LIBRARY_FUNCTION)
     {
-      System.loadLibrary("DShowTranscode");
+      sage.Native.loadLibrary("DShowTranscode");
     }
   }
 

--- a/java/sage/DVDReader.java
+++ b/java/sage/DVDReader.java
@@ -54,7 +54,7 @@ public class DVDReader
 
   public DVDReader()
   {
-    System.loadLibrary("DVDReader");
+    sage.Native.loadLibrary("DVDReader");
   }
 
   public synchronized boolean open(String path)

--- a/java/sage/DirecTVSerialControl.java
+++ b/java/sage/DirecTVSerialControl.java
@@ -59,7 +59,7 @@ public class DirecTVSerialControl
       if (!loadedLib)
       {
         if(!Sage.MAC_OS_X) // included libSage...
-          System.loadLibrary("DirecTVSerialControl");
+          sage.Native.loadLibrary("DirecTVSerialControl");
         loadedLib = true;
       }
     }

--- a/java/sage/DirectX9SageRenderer.java
+++ b/java/sage/DirectX9SageRenderer.java
@@ -56,12 +56,12 @@ public class DirectX9SageRenderer extends SageRenderer implements NativeImageAll
     {
       if (Sage.WINDOWS_OS)
       {
-        System.loadLibrary("SageTVDX93D");
+        sage.Native.loadLibrary("SageTVDX93D");
         loadedDX9Lib = true;
       }
       else
       {
-        System.loadLibrary("SageTVOGL");
+        sage.Native.loadLibrary("SageTVOGL");
         loadedDX9Lib = true;
       }
     }

--- a/java/sage/FreetypeFont.java
+++ b/java/sage/FreetypeFont.java
@@ -32,7 +32,7 @@ public class FreetypeFont extends MetaFont
       synchronized (ftLock)
       {
         if (ftLibPtr != 0) return;
-        System.loadLibrary("FreetypeFontJNI");
+        sage.Native.loadLibrary("FreetypeFontJNI");
         ftLibPtr = loadFreetypeLib0();
         if (ftLibPtr == 0)
         {

--- a/java/sage/HDHomeRunCaptureManager.java
+++ b/java/sage/HDHomeRunCaptureManager.java
@@ -24,7 +24,7 @@ public class HDHomeRunCaptureManager implements CaptureDeviceManager
   public HDHomeRunCaptureManager() throws Throwable
   {
     try {
-      System.loadLibrary("HDHomeRunCapture");
+      sage.Native.loadLibrary("HDHomeRunCapture");
       hdhrEnabled = true;
     } catch (Throwable t) {
       System.out.println("Unable to load HDHomeRun capture manager: " + t);

--- a/java/sage/LinuxDVBCaptureManager.java
+++ b/java/sage/LinuxDVBCaptureManager.java
@@ -25,7 +25,7 @@ public class LinuxDVBCaptureManager implements CaptureDeviceManager
   /** Creates a new instance of LinuxDVBCaptureManager */
   public LinuxDVBCaptureManager()
   {
-    System.loadLibrary("DVBCapture");
+    sage.Native.loadLibrary("DVBCapture");
     prefs = MMC.MMC_KEY + '/';
     mmc = MMC.getInstance();
     encoderMap = new java.util.LinkedHashMap();

--- a/java/sage/LinuxFirewireCaptureManager.java
+++ b/java/sage/LinuxFirewireCaptureManager.java
@@ -25,7 +25,7 @@ public class LinuxFirewireCaptureManager implements CaptureDeviceManager
   /** Creates a new instance of LinuxFirewireCaptureManager */
   public LinuxFirewireCaptureManager()
   {
-    System.loadLibrary("FirewireCapture");
+    sage.Native.loadLibrary("FirewireCapture");
     prefs = MMC.MMC_KEY + '/';
     mmc = MMC.getInstance();
     encoderMap = new java.util.LinkedHashMap();

--- a/java/sage/LinuxIVTVCaptureManager.java
+++ b/java/sage/LinuxIVTVCaptureManager.java
@@ -37,7 +37,7 @@ public class LinuxIVTVCaptureManager implements CaptureDeviceManager
 
   {
 
-    System.loadLibrary("IVTVCapture");
+    sage.Native.loadLibrary("IVTVCapture");
 
     prefs = MMC.MMC_KEY + '/';
 

--- a/java/sage/MacIRC.java
+++ b/java/sage/MacIRC.java
@@ -48,7 +48,7 @@ public class MacIRC implements sage.SageTVInputPlugin
   {
     if(!available) {
       try {
-        System.loadLibrary("MacIRC");
+        sage.Native.loadLibrary("MacIRC");
         available = true;
       } catch(Throwable t) {
         //				System.out.println("ERROR loading MacIRC library: "+t);

--- a/java/sage/MacNativeCaptureManager.java
+++ b/java/sage/MacNativeCaptureManager.java
@@ -24,7 +24,7 @@ public class MacNativeCaptureManager implements CaptureDeviceManager
   public MacNativeCaptureManager() throws Throwable
   {
     try {
-      System.loadLibrary("MacNativeCapture");
+      sage.Native.loadLibrary("MacNativeCapture");
     } catch (Throwable t) {
       System.out.println("Unable to load native capture manager: " + t);
       throw t;

--- a/java/sage/Mpeg2Transcoder.java
+++ b/java/sage/Mpeg2Transcoder.java
@@ -48,7 +48,7 @@ public final class Mpeg2Transcoder
     mpegFile = theFile;
     hostname = inHostname;
     System.out.println("Creating Mpeg2Transcoder");
-    System.loadLibrary("Mpeg2Transcoder");
+    sage.Native.loadLibrary("Mpeg2Transcoder");
   }
 
   public void setLogging(boolean x)

--- a/java/sage/Native.java
+++ b/java/sage/Native.java
@@ -1,0 +1,44 @@
+package sage;
+
+import java.util.TreeSet;
+
+/**
+ * Wraps the native library loading so that we can better contain failures.  This was done because some Java test code
+ * relies on Sage.java and Sage.java cannot be initialized if it is missing the native parts.  This allows it be
+ * initialized since 90% of tests are not using the native parts, but, still needs access to Sage.DBG, etc.
+ *
+ * Created by seans on 03/09/16.
+ */
+public class Native
+{
+  // by default (ie, runtime we'd want to log this) but during testing, we'll set to not log to make it cleaner
+  public static boolean LOG_NATIVE_FAILURES = true;
+
+  // if we have any NATIVE failures this goes to true.
+  public static boolean NATIVE_FAILED = false;
+  public static TreeSet<String> FAILED_NATIVES = new TreeSet<String>();
+
+  /**
+   * Load the given system library and optionally log the failure if it cannot be loaded.  This never throws an Exception, but
+   * it will set the FAILED_NATIVES to true if there libraries the fail to load.  The logic here is that it's better
+   * to log it and let the code carry on, which it may fail later, but at least it will be logged.  Currently most
+   * System.loadLibrary calls are in the static section of class initialization, so when it can't find a System Library
+   * we end with a Class Initialization error that sometimes masks the real issue (ie, can't load the library)
+   *
+   * @param lib System Library
+   */
+  public static void loadLibrary(String lib)
+  {
+    try
+    {
+      System.loadLibrary(lib);
+    }
+    catch (Throwable t)
+    {
+      NATIVE_FAILED=true;
+      if (LOG_NATIVE_FAILURES && !FAILED_NATIVES.contains(lib))
+        t.printStackTrace();
+      FAILED_NATIVES.add(lib);
+    }
+  }
+}

--- a/java/sage/PVR150Input.java
+++ b/java/sage/PVR150Input.java
@@ -25,7 +25,7 @@ public class PVR150Input implements SageTVInputPlugin
   {
     if (!loadedLib && !Sage.EMBEDDED)
     {
-      System.loadLibrary("PVR150Input");
+      sage.Native.loadLibrary("PVR150Input");
       loadedLib = true;
     }
   }

--- a/java/sage/PVR350OSDRenderingPlugin.java
+++ b/java/sage/PVR350OSDRenderingPlugin.java
@@ -22,7 +22,7 @@ public class PVR350OSDRenderingPlugin implements OSDRenderingPlugin
 	{
 		if (!loadedLib && !SageConstants.LITE)
 		{
-			System.loadLibrary("PVR350OSDPlugin");
+			sage.Native.loadLibrary("PVR350OSDPlugin");
 			loadedLib = true;
 			Sage.writeDwordValue(Sage.HKEY_LOCAL_MACHINE,
 				"SYSTEM\\CurrentControlSet\\Services\\Globespan\\Parameters\\ivac15\\Driver",

--- a/java/sage/SFIRTuner.java
+++ b/java/sage/SFIRTuner.java
@@ -22,7 +22,7 @@ public class SFIRTuner implements Runnable
 {
   static
   {
-    //System.loadLibrary("Sage");
+    //sage.Native.loadLibrary("Sage");
   }
   public static final String REMOTE_DIR = "remote_dir";
   public static final String IRTUNE_REPEAT_FACTOR = "irtune_repeat_factor";

--- a/java/sage/Sage.java
+++ b/java/sage/Sage.java
@@ -15,6 +15,12 @@
  */
 package sage;
 
+import javax.swing.BorderFactory;
+import javax.swing.BoxLayout;
+import javax.swing.JComponent;
+import javax.swing.JMenuItem;
+import javax.swing.JPopupMenu;
+import javax.swing.JWindow;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Container;
@@ -34,12 +40,10 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.geom.Rectangle2D;
 import java.io.BufferedOutputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.DataInput;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InterruptedIOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
@@ -56,6 +60,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.Enumeration;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -73,13 +78,6 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.Vector;
 
-import javax.swing.BorderFactory;
-import javax.swing.BoxLayout;
-import javax.swing.JComponent;
-import javax.swing.JMenuItem;
-import javax.swing.JPopupMenu;
-import javax.swing.JWindow;
-
 public final class Sage
 {
   // This makes the service fail if TRUE
@@ -91,6 +89,16 @@ public final class Sage
   public static boolean MAC_OS_X = false;
   public static boolean VISTA_OS = false; // if this is true, then WINDOWS_OS is also true
   public static boolean EMBEDDED = false;
+
+  /**
+   * Testing is set to true when the sage.testing System Property is set.  TESTING has a special meaning
+   * in that some function calls/behaviours will be different.  ie, Generally in TESTING the NATIVE parts fail
+   * to load, and as such we tend to avoid calling native methods.  Also STDOUT/STDERR are NOT redirected to a
+   * file when TESTING is enabled.
+   */
+  public static boolean TESTING = false;
+
+
   public static final boolean PERF_ANALYSIS = false;
   public static final long UI_BUILD_THRESHOLD_TIME = 1;
   public static final long EVALUATE_THRESHOLD_TIME = 1;
@@ -103,6 +111,7 @@ public final class Sage
   public static boolean USE_HIRES_TIME = true;
   static
   {
+    TESTING = "true".equalsIgnoreCase(System.getProperty("sage.testing"));
     EMBEDDED = System.getProperty("sage.embedded") != null;
     WINDOWS_OS = System.getProperty("os.name").toLowerCase().indexOf("windows") != -1;
     MAC_OS_X = System.getProperty("os.name").toLowerCase().indexOf("mac os x") != -1;
@@ -110,9 +119,9 @@ public final class Sage
     VISTA_OS = WINDOWS_OS && (System.getProperty("os.version").startsWith("6.") || System.getProperty("os.version").startsWith("7."));
 
     if (WINDOWS_OS)
-      System.loadLibrary("SageTVWin32");
+      sage.Native.loadLibrary("SageTVWin32");
     else
-      System.loadLibrary("Sage");
+      sage.Native.loadLibrary("Sage");
 
     if (EMBEDDED)
     {
@@ -121,9 +130,13 @@ public final class Sage
       USE_HIRES_TIME = false;
     }
     baseSystemTime = System.currentTimeMillis();
-    baseEventTime = getEventTime0();
-    baseCPUTime = getCpuTime();
-    cpuFreq = getCpuResolution();
+    // prevents SageTV initialization when the Native libraries are not loaded (or can't be loaded)
+    if (!Native.NATIVE_FAILED)
+    {
+      baseEventTime = getEventTime0();
+      baseCPUTime = getCpuTime();
+      cpuFreq = getCpuResolution();
+    }
     createDFFormats();
   }
 
@@ -192,7 +205,10 @@ public final class Sage
         return cputime;
     }
     else
-      return getEventTime0();
+      if (!Native.NATIVE_FAILED)
+        return getEventTime0();
+      else
+        return System.currentTimeMillis();
   }
 
   public static int getHKEYForName(String s)
@@ -754,9 +770,12 @@ public final class Sage
         redir = new MyPrinter(prefix, outputFile, new BufferedOutputStream(
             new FileOutputStream(outputFile)), false);
 
-        System.setOut(redir);
-        if (stdOutHandle != 0)
-          System.setErr(redir);
+        if (!TESTING)
+        {
+          System.setOut(redir);
+          if (stdOutHandle != 0)
+            System.setErr(redir);
+        }
       }
       catch (IOException e)
       {
@@ -791,10 +810,13 @@ public final class Sage
               }
             }
           };
-          System.out.close();
-          System.err.close();
-          System.setOut(redir);
-          System.setErr(redir);
+          if (!TESTING)
+          {
+            System.out.close();
+            System.err.close();
+            System.setOut(redir);
+            System.setErr(redir);
+          }
         }
         catch (IOException e)
         {
@@ -836,9 +858,12 @@ public final class Sage
               }
             }
           };
-          System.setOut(redir);
-          if (stdOutHandle != 0)
-            System.setErr(redir);
+          if (!TESTING)
+          {
+            System.setOut(redir);
+            if (stdOutHandle != 0)
+              System.setErr(redir);
+          }
         }
         catch (IOException e)
         {
@@ -928,8 +953,11 @@ public final class Sage
         }
       };
 
-      System.setOut(redir);
-      System.setErr(redir);
+      if (!TESTING)
+      {
+        System.setOut(redir);
+        System.setErr(redir);
+      }
     }
   }
 
@@ -960,6 +988,7 @@ public final class Sage
     if (!SageConstants.LITE)
       startup(args);
   }
+
   static void startup(String[] args) throws Throwable
   {
     try
@@ -1107,7 +1136,28 @@ public final class Sage
         userLocale = new Locale(preferredLanguage, preferredCountry);
       else
         userLocale = Locale.getDefault();
-      coreRez = ResourceBundle.getBundle("SageTVCoreTranslations", userLocale);
+      if (TESTING)
+      {
+        coreRez = new ResourceBundle()
+        {
+          Vector<String> keys = new Vector<String>();
+          @Override
+          protected Object handleGetObject(String s)
+          {
+            keys.add(s);
+            return s;
+          }
+
+          @Override
+          public Enumeration<String> getKeys()
+          {
+            return keys.elements();
+          }
+        };
+      } else
+      {
+        coreRez = ResourceBundle.getBundle("SageTVCoreTranslations", userLocale);
+      }
       createDFFormats();
       UserEvent.updateNameMaps();
 
@@ -1170,7 +1220,8 @@ public final class Sage
       {
         new ThreadMonitor(Sage.getLong("thread_cpu_monitor_interval", 5 * MILLIS_PER_MIN));
       }
-      new SageTV();
+      if (!TESTING)
+        new SageTV();
     }
     catch (Throwable t)
     {

--- a/java/sage/SageConstants.java
+++ b/java/sage/SageConstants.java
@@ -27,5 +27,5 @@ public final class SageConstants
   public static final boolean PVR = true;
   public static final boolean SERVER_FUNCTION = true;
   public static final boolean LIBRARY_FUNCTION = true;
-  public static final int BUILD_VERSION = 3;
+  public static final int BUILD_VERSION = 349;
 }

--- a/java/sage/SageTVInfraredReceive.java
+++ b/java/sage/SageTVInfraredReceive.java
@@ -23,7 +23,7 @@ public abstract class SageTVInfraredReceive implements SageTVInputPlugin
   {
     if (!loadedLib)
     {
-      System.loadLibrary("SageTVInfraredReceive");
+      sage.Native.loadLibrary("SageTVInfraredReceive");
       loadedLib = true;
     }
   }

--- a/java/sage/ServerPowerManagement.java
+++ b/java/sage/ServerPowerManagement.java
@@ -36,9 +36,9 @@ public class ServerPowerManagement extends PowerManagement
   {
     super();
     if (Sage.WINDOWS_OS)
-      System.loadLibrary("SageTVWin32");
+      sage.Native.loadLibrary("SageTVWin32");
     else if (Sage.MAC_OS_X)
-      System.loadLibrary("Sage");
+      sage.Native.loadLibrary("Sage");
     extendersKeepServerOn = Sage.getBoolean("extender_power_keeps_server_out_of_standby", false);
   }
 

--- a/java/sage/VideoFrame.java
+++ b/java/sage/VideoFrame.java
@@ -48,7 +48,7 @@ public final class VideoFrame extends BasicVideoFrame implements Runnable
   {
     if (Sage.WINDOWS_OS)
     {
-      System.loadLibrary("DShowPlayer");
+      sage.Native.loadLibrary("DShowPlayer");
     }
 
     if (mediaLangMap == null)

--- a/java/sage/WindowsServiceControl.java
+++ b/java/sage/WindowsServiceControl.java
@@ -255,7 +255,7 @@ public class WindowsServiceControl implements ActionListener
 
   private WindowsServiceControl()
   {
-    System.loadLibrary("SageTVWin32");
+    sage.Native.loadLibrary("SageTVWin32");
     ptr = openServiceHandle0("SageTV");
     f = new JFrame(rez("SageTV_Service_Control"));
     f.addWindowListener(new WindowAdapter()

--- a/java/sage/media/format/MPEGParser.java
+++ b/java/sage/media/format/MPEGParser.java
@@ -29,7 +29,7 @@ public class MPEGParser
     {
       try
       {
-        System.loadLibrary("MPEGParser");
+        sage.Native.loadLibrary("MPEGParser");
       }
       catch (Throwable t)
       {

--- a/java/sage/media/format/MPEGParser2.java
+++ b/java/sage/media/format/MPEGParser2.java
@@ -70,7 +70,7 @@ public class MPEGParser2
     {
       try
       {
-        System.loadLibrary("JavaRemuxer2");
+        sage.Native.loadLibrary("JavaRemuxer2");
       }
       catch (Throwable t)
       {

--- a/java/sage/media/image/ImageLoader.java
+++ b/java/sage/media/image/ImageLoader.java
@@ -29,7 +29,7 @@ public class ImageLoader
     EMBEDDED = System.getProperty("sage.embedded") != null;
     try
     {
-      System.loadLibrary("ImageLoader");
+      sage.Native.loadLibrary("ImageLoader");
     }
     catch (Throwable t)
     {

--- a/java/sage/miniclient/DirectX9GFXCMD.java
+++ b/java/sage/miniclient/DirectX9GFXCMD.java
@@ -48,7 +48,7 @@ public class DirectX9GFXCMD extends GFXCMD2
 
     if (!loadedDX9Lib)
     {
-      System.loadLibrary("SageTVDX93D");
+      sage.Native.loadLibrary("SageTVDX93D");
       loadedDX9Lib = true;
       registerMiniClientNatives0();
     }

--- a/java/sage/miniclient/MiniClient.java
+++ b/java/sage/miniclient/MiniClient.java
@@ -100,7 +100,7 @@ public class MiniClient
   {
     if(MAC_OS_X) {
       try {
-        System.loadLibrary("MiniClient");
+        sage.Native.loadLibrary("MiniClient");
       } catch (Throwable t) {
         System.out.println("Exception occured loading MiniClient library: "+t);
       }

--- a/java/sage/miniclient/MiniClientPowerManagement.java
+++ b/java/sage/miniclient/MiniClientPowerManagement.java
@@ -36,7 +36,7 @@ public class MiniClientPowerManagement extends sage.PowerManagement
   {
     super();
     if (MiniClient.WINDOWS_OS)
-      System.loadLibrary("SageTVWin32");
+      sage.Native.loadLibrary("SageTVWin32");
   }
 
   // Determine the current power state

--- a/java/sage/miniclient/MiniClientWindow.java
+++ b/java/sage/miniclient/MiniClientWindow.java
@@ -82,7 +82,7 @@ public class MiniClientWindow extends sage.SageTVWindow
     {
       try
       {
-        System.loadLibrary("Sage");
+        sage.Native.loadLibrary("Sage");
       }
       catch (Throwable t)
       {

--- a/java/sage/miniclient/MiniMPlayerPlugin.java
+++ b/java/sage/miniclient/MiniMPlayerPlugin.java
@@ -433,7 +433,7 @@ public class MiniMPlayerPlugin implements Runnable
           {
             // Setup the color key parameter for the overlay
             cmdOpt2 += " -vo directx:colorkey=" + Integer.toString(getDesktopColorKey());
-            System.loadLibrary("SageTVWin32");
+            sage.Native.loadLibrary("SageTVWin32");
             cmdOpt2 += " -wid " + sage.UIUtils.getHWND(target);
           }
           cmdOpt2 += " -nokeepaspect";
@@ -497,7 +497,7 @@ public class MiniMPlayerPlugin implements Runnable
           if (!"true".equals(MiniClient.myProperties.getProperty("opengl", "true")))
           {
             try {
-              System.loadLibrary("Sage");
+              sage.Native.loadLibrary("Sage");
               cmdOpt2 += " -wid " + sage.UIUtils.getHWND(target);
             } catch (Throwable t) {}
           }

--- a/java/sage/miniclient/OpenGLVideoRenderer.java
+++ b/java/sage/miniclient/OpenGLVideoRenderer.java
@@ -54,7 +54,7 @@ public class OpenGLVideoRenderer
         initVideoServer();
       else if (MiniClient.WINDOWS_OS)
       {
-        System.loadLibrary("SageTVWin32");
+        sage.Native.loadLibrary("SageTVWin32");
         // For Windows we create the thread in Java
         Thread t = new Thread("OpenGLVideo")
         {


### PR DESCRIPTION
These changes make SageTV easier to unit since it prevents SageTV from crashing if the native libraries are not there (which is likely the case when you unit testing during a build cycle).

Native.java is a wrapper around System.loadLibrary().  Most of the changes are simply to replace System.loadLibrary with Native.loadLibrary, and Native.loadLibrary does not throw an exception... it just logs the missing library.

Sage.java has some changes around it's initialization to prevent it from crashing when the native libraries are missing.   It also has a new flag TESTING that changes can be used to conditionally initalize some code when testing... ie, when TESTING we don't want sagetv to redirect stdout, etc.