### PR TITLE
IOUtils test fails on Windows.

### DIFF
--- a/test/java/sage/IOUtilsTest.java
+++ b/test/java/sage/IOUtilsTest.java
@@ -14,13 +14,13 @@ public class IOUtilsTest
   public void testGetUrlAsString() throws Exception
   {
     String md5 = IOUtils.getUrlAsString(file2url(getTestResource("test-jar-1.0.zip.md5")));
-    assertEquals(md5, "beec1608cf997d3acb42f0ab772b143f\n");
+    assertEquals(md5, "beec1608cf997d3acb42f0ab772b143f" + System.lineSeparator());
   }
 
   @Test
   public void testReadFileAsString() throws Exception
   {
     String md5 = IOUtils.getFileAsString(getTestResource("test-jar-1.0.zip.md5"));
-    assertEquals(md5, "beec1608cf997d3acb42f0ab772b143f\n");
+    assertEquals(md5, "beec1608cf997d3acb42f0ab772b143f" + System.lineSeparator());
   }
 }


### PR DESCRIPTION
The problem is the line separator in Linux and Windows are different.