### PR TITLE
Change extended filenames logic

### DIFF
--- a/java/sage/MediaFile.java
+++ b/java/sage/MediaFile.java
@@ -73,7 +73,7 @@ public class MediaFile extends DBObject implements SegmentedFile
   private static final boolean VIDEO_THUMBNAIL_FILE_GEN = Sage.getBoolean("video_thumbnail_generation", true);
   private static final String THUMB_FOLDER_NAME = Sage.get("ui/thumbnail_folder", "GeneratedThumbnails");
   public static final File THUMB_FOLDER = new File(Sage.getPath("cache"), THUMB_FOLDER_NAME);
-  public static final String ILLEGAL_FILE_NAME_CHARACTERS = "\\/:*?<>|\"";  // Jeff Harrison - 10/2/2015
+  public static final String LEGAL_FILE_NAME_CHARACTERS = " `!@#$%^&()-_+={}[];',";		// Jeff Harrison - 09/10/2016
 
   // Ensure this directory is created, we rely on this in a few places
   static
@@ -4266,9 +4266,9 @@ public class MediaFile extends DBObject implements SegmentedFile
       } else if ((c >= 'a' && c <= 'z') ||
         (c >= '0' && c <= '9') ||
         (c >= 'A' && c <= 'Z') ||
-        // Jeff Harrison - 10/2/2015
-        // Keep spaces and other extra characters in filenames excluding illegal characters
-        (Sage.getBoolean("extended_filenames", false) && !ILLEGAL_FILE_NAME_CHARACTERS.contains(c + "")))
+        // Jeff Harrison - 09/10/2016
+     	// Keep spaces and other extra characters in filenames
+        (Sage.getBoolean("extended_filenames", false) && LEGAL_FILE_NAME_CHARACTERS.contains(c + "")))
           sb.append(c);
     }
     return sb.toString();


### PR DESCRIPTION
Change the logic to determine valid characters in extended filenames to
a whitelist. Unicode characters in filenames were causing file system
errors in Linux.