### PR TITLE
’Test99: Namé’ is becoming ’Test99: NamÃ©’ on Windows.

### DIFF
--- a/test/java/sage/MediaFileTest.java
+++ b/test/java/sage/MediaFileTest.java
@@ -16,12 +16,12 @@ public class MediaFileTest
   public void testCreateValidFilename() throws Throwable
   {
     TestUtils.initializeSageTVForTesting();
-    String fname="\u2019Test99: Namé\u2019";
+    String fname="\u2019Test99: Nam\u00E9\u2019"; // \u00E9 = é
     boolean allowUnicode,extendedFileName;
 
     // test with unicode
-    validateFile(fname, "Test99Namé", allowUnicode=true, extendedFileName=false);
-    validateFile(fname, "Test99 Namé", allowUnicode=true, extendedFileName=true);
+    validateFile(fname, "Test99Nam\u00E9", allowUnicode=true, extendedFileName=false);
+    validateFile(fname, "Test99 Nam\u00E9", allowUnicode=true, extendedFileName=true);
 
     // test no unicode
     validateFile(fname, "Test99Nam", allowUnicode=false, extendedFileName=false);


### PR DESCRIPTION
The test isn't working on Windows. ’Test99: Namé’ is being turned into ’Test99: NamÃ©’ by the compiler. I looked up the UTF-8  code for this the character é and it's 0xC3A9 which explains how one character somehow became two (even though that should fit within a character; maybe a bug in Java too). Oddly enough in UTF-16, it's 0x00E9, so I change é to \u00E9 and now the test is passing.