### PR TITLE
Fixed bug in the EPG license detection logic. We now also check for NOKEY.

### DIFF
--- a/java/sage/WarlockRipper.java
+++ b/java/sage/WarlockRipper.java
@@ -279,7 +279,7 @@ public class WarlockRipper extends EPGDataSource
     // NOTE: This of course is not the only way EPG clients are being validated...we're not that
     // dumb, ya know?  This is just to avoid people hitting the server who don't have a license.
     String key = getEPGLicenseKey();
-    return (key != null && key.length() > 0);
+    return (key != null && key.length() > 0 && !key.equals("NOKEY"));
   }
 
   // This may take some time due to the diskspace calculation so do it before we connect to the server


### PR DESCRIPTION
This is a real problem for people using XMLTV plugins because they keep getting error messages and the guide data is not being imported. Not surprisingly, this does not prevent the plugin itself from loading, but since we check for the license key before we try to use the plugin, it fails immediately.