### PR TITLE
Schedules Direct fixes and updates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
 # Change Log
 
+## Version 9.0.9 (2016-10-04)
+* New: Added logic to Schedules Direct program categories to ensure Movie is the first category for programs that start with MV
+* Fix: Cleaned up the logic for determining when images from Schedules Direct should be in a Show or SeriesInfo object
+* Fix: Clarified in logging when we can't process anything currently because Schedules Direct is offline
+* Fix: Added random timeout when Schedules Direct token expires before getting a new token in case there are multiple SageTV servers using the same account
+
 ## Version 9.0.8.429 (2016-09-27)
 * Fix: Fixed plugin bug that caused some upgraded plugins to be in a corrupted state
 * Fix: Fixed bug in the EPG license detection logic
 
 ## Version 9.0.8 (2016-09-22)
-* New: Added Schedules Direct EPG support as a core BETA feature.
+* New: Added Schedules Direct EPG support as a core BETA feature
 
 ## Version 9.0.7 (2016-08-10)
 * New: Added SageTVPluginsDev.d directory support (See [SageTVPluginsDev README](SageTVPluginsDev.md))

--- a/java/sage/Version.java
+++ b/java/sage/Version.java
@@ -23,7 +23,7 @@ public class Version
 {
   public static final byte MAJOR_VERSION = 9;
   public static final byte MINOR_VERSION = 0;
-  public static final byte MICRO_VERSION = 8;
+  public static final byte MICRO_VERSION = 9;
 
   public static final String VERSION = MAJOR_VERSION + "." + MINOR_VERSION + "." + MICRO_VERSION + "." + SageConstants.BUILD_VERSION;
 

--- a/java/sage/epg/sd/SDSageSession.java
+++ b/java/sage/epg/sd/SDSageSession.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.URL;
+import java.util.Random;
 
 public class SDSageSession extends SDSession
 {
@@ -140,6 +141,16 @@ public class SDSageSession extends SDSession
       if (retry && connection.getResponseCode() == 403)
       {
         token = null;
+
+        try
+        {
+          // Wait a random interval between 1 and 30000 milliseconds in case more than one SageTV
+          // server is updating at the same time. This should effectively get them out of sync each
+          // time they overlap and potentially give the other server a chance to complete it's most
+          // recent communication before we get a new token.
+          Thread.sleep((new Random()).nextInt(30000) + 1);
+        } catch (InterruptedException e) {}
+
         authenticate();
         return post(url, sendBytes, off, len, false);
       }
@@ -183,6 +194,16 @@ public class SDSageSession extends SDSession
     if (retry && connection.getResponseCode() == 403)
     {
       token = null;
+
+      try
+      {
+        // Wait a random interval between 1 and 30000 milliseconds in case more than one SageTV
+        // server is updating at the same time. This should effectively get them out of sync each
+        // time they overlap and potentially give the other server a chance to complete it's most
+        // recent communication before we get a new token.
+        Thread.sleep((new Random()).nextInt(30000) + 1);
+      } catch (InterruptedException e) {}
+
       authenticate();
       return get(url, false);
     }

--- a/test/java/sage/epg/sd/SDImagesTest.java
+++ b/test/java/sage/epg/sd/SDImagesTest.java
@@ -16,11 +16,13 @@
 package sage.epg.sd;
 
 import org.testng.annotations.Test;
+import sage.Show;
 import sage.epg.sd.json.images.SDImage;
 import sage.epg.sd.json.images.SDProgramImages;
 import sage.epg.sd.json.map.SDLineupMap;
 import sage.epg.sd.json.map.station.SDLogo;
 import sage.epg.sd.json.map.station.SDStation;
+import sage.epg.sd.json.programs.SDProgram;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -80,15 +82,15 @@ public class SDImagesTest extends DeserializeTest
   @Test(groups = {"gson", "schedulesDirect", "images", "series" })
   public void seriesEncodingTest() throws IOException
   {
-    String programImages = "epg/sd/json/images/programImagesEpisode.json";
+    String programImages = "epg/sd/json/images/programImagesShow.json";
     SDProgramImages images[] = deserialize(programImages, SDProgramImages[].class);
     int[] showcardID = new int[1];
-    byte[][] packedImages = SDImages.encodeImages(images[0].getImages(), showcardID, SDImages.ENCODE_NON_SERIES_ONLY);
-    verifyImages(images[0].getImages(), packedImages, showcardID[0], 7);
+    byte[][] packedImages = SDImages.encodeImages(images[0].getImages(), showcardID, SDImages.ENCODE_SERIES_ONLY);
+    verifyImages(images[0].getImages(), packedImages, showcardID[0], 5);
 
     showcardID[0] = 0;
     packedImages = SDImages.encodeImages(images[0].getImages(), showcardID, SDImages.ENCODE_ALL);
-    verifyImages(images[0].getImages(), packedImages, showcardID[0], 15);
+    assert packedImages.length == 0;
   }
 
   @Test(groups = {"gson", "schedulesDirect", "images", "movie" })
@@ -99,6 +101,17 @@ public class SDImagesTest extends DeserializeTest
     int[] showcardID = new int[1];
     byte[][] packedImages = SDImages.encodeImages(images[0].getImages(), showcardID, SDImages.ENCODE_ALL);
     verifyImages(images[0].getImages(), packedImages, showcardID[0], 22);
+  }
+
+  @Test(groups = {"gson", "schedulesDirect", "images", "episode" })
+  public void episodeEncodingTest() throws IOException
+  {
+    String episode = "epg/sd/json/programs/programEpisode.json";
+    SDProgram program = deserialize(episode, SDProgram.class);
+    int[] showcardID = new int[1];
+    byte[][] packedImages = SDImages.encodeEpisodeImage(program.getEpisodeImage(), showcardID);
+    assert packedImages.length == 2;
+    assert SDImages.getImageCount(SDImages.getSDIndexForShowType(Show.IMAGE_PHOTO_THUMB_TALL), packedImages) == 1;
   }
 
   @Test(groups = {"gson", "schedulesDirect", "images", "channelLogo" })

--- a/test/java/sage/epg/sd/json/images/SDProgramImagesDeserializerTest.java
+++ b/test/java/sage/epg/sd/json/images/SDProgramImagesDeserializerTest.java
@@ -33,7 +33,6 @@ public class SDProgramImagesDeserializerTest extends DeserializeTest
   @Test(groups = {"gson", "schedulesDirect", "program", "images", "error" })
   public void deserializeTMSError() throws IOException
   {
-    //[{"programID":"SH02468914","data":{"errorCode":1013,"errorMessage":"invalid_tms_id"}}]
     String error = "epg/sd/json/errors/tms1013.json";
     SDProgramImages program[] = deserialize(error, SDProgramImages[].class);
     assert program[0].getCode() == 6000;
@@ -47,7 +46,7 @@ public class SDProgramImagesDeserializerTest extends DeserializeTest
 
     assert images[0].getCode() == 0;
     assert images[0].getImages() != null;
-    assert "SH01915214".equals(images[0].getProgramID());
+    assert "SH01966829".equals(images[0].getProgramID());
     for (SDImage image : images[0].getImages())
     {
       assert image.getHeight() != 0;

--- a/test/resources/epg/sd/json/images/programImagesShow.json
+++ b/test/resources/epg/sd/json/images/programImagesShow.json
@@ -1,507 +1,11 @@
 [
   {
-    "programID": "SH01915214",
+    "programID": "SH01966829",
     "data": [
       {
-        "width": "720",
-        "height": "540",
-        "uri": "https://s3.amazonaws.com/schedulesdirect/assets/p184072_l_h6_ab.jpg",
-        "size": "Lg",
-        "aspect": "4x3",
-        "category": "Logo",
-        "text": "yes",
-        "primary": "true",
-        "tier": "Series"
-      },
-      {
-        "width": "270",
-        "height": "360",
-        "caption": {
-          "content": "Hoda Kotb",
-          "lang": "en"
-        },
-        "uri": "assets/p184072_n395437_cc_v3_aa.jpg",
-        "size": "Md",
-        "aspect": "3x4",
-        "category": "Cast in Character",
-        "text": "no",
-        "primary": "true",
-        "tier": "Series"
-      },
-      {
-        "width": "540",
-        "height": "720",
-        "caption": {
-          "content": "Hoda Kotb",
-          "lang": "en"
-        },
-        "uri": "assets/p184072_n395437_cc_v4_aa.jpg",
-        "size": "Lg",
-        "aspect": "3x4",
-        "category": "Cast in Character",
-        "text": "no",
-        "primary": "true",
-        "tier": "Series"
-      },
-      {
-        "width": "135",
-        "height": "180",
-        "caption": {
-          "content": "Natalie Morales",
-          "lang": "en"
-        },
-        "uri": "assets/p184072_n510264_cc_v2_aa.jpg",
-        "size": "Sm",
-        "aspect": "3x4",
-        "category": "Cast in Character",
-        "text": "no",
-        "primary": "true",
-        "tier": "Series"
-      },
-      {
-        "width": "540",
-        "height": "720",
-        "caption": {
-          "content": "Kathie Lee Gifford",
-          "lang": "en"
-        },
-        "uri": "assets/p184072_n634_cc_v4_aa.jpg",
-        "size": "Lg",
-        "aspect": "3x4",
-        "category": "Cast in Character",
-        "text": "no",
-        "primary": "true",
-        "tier": "Series"
-      },
-      {
-        "width": "540",
-        "height": "720",
-        "caption": {
-          "content": "Matt Lauer",
-          "lang": "en"
-        },
-        "uri": "assets/p184072_n70280_cc_v4_aa.jpg",
-        "size": "Lg",
-        "aspect": "3x4",
-        "category": "Cast in Character",
-        "text": "no",
-        "primary": "true",
-        "tier": "Series"
-      },
-      {
-        "width": "540",
-        "height": "720",
-        "caption": {
-          "content": "Willie Geist",
-          "lang": "en"
-        },
-        "uri": "assets/p184072_n554890_cc_v4_aa.jpg",
-        "size": "Lg",
-        "aspect": "3x4",
-        "category": "Cast in Character",
-        "text": "no",
-        "primary": "true",
-        "tier": "Series"
-      },
-      {
-        "width": "270",
-        "height": "360",
-        "caption": {
-          "content": "Carson Daly",
-          "lang": "en"
-        },
-        "uri": "assets/p184072_n173491_cc_v3_aa.jpg",
-        "size": "Md",
-        "aspect": "3x4",
-        "category": "Cast in Character",
-        "text": "no",
-        "primary": "true",
-        "tier": "Series"
-      },
-      {
-        "width": "180",
-        "height": "135",
-        "caption": {
-          "content": "Al Roker, Savannah Guthrie, Matt Lauer and Natalie Morales (from left)",
-          "lang": "en"
-        },
-        "uri": "https://s3.amazonaws.com/schedulesdirect/assets/p184072_ce_h5_aa.jpg",
-        "size": "Sm",
-        "aspect": "4x3",
-        "category": "Cast Ensemble",
-        "text": "no",
-        "primary": "true",
-        "tier": "Series"
-      },
-      {
-        "width": "135",
-        "height": "180",
-        "caption": {
-          "content": "Hoda Kotb",
-          "lang": "en"
-        },
-        "uri": "assets/p184072_n395437_cc_v2_aa.jpg",
-        "size": "Sm",
-        "aspect": "3x4",
-        "category": "Cast in Character",
-        "text": "no",
-        "primary": "true",
-        "tier": "Series"
-      },
-      {
-        "width": "360",
-        "height": "270",
-        "caption": {
-          "content": "Al Roker, Savannah Guthrie, Matt Lauer and Natalie Morales (from left)",
-          "lang": "en"
-        },
-        "uri": "https://s3.amazonaws.com/schedulesdirect/assets/p184072_ce_h3_aa.jpg",
-        "size": "Md",
-        "aspect": "4x3",
-        "category": "Cast Ensemble",
-        "text": "no",
-        "primary": "true",
-        "tier": "Series"
-      },
-      {
-        "width": "267",
-        "height": "200",
-        "caption": {
-          "content": "Al Roker, Savannah Guthrie, Matt Lauer and Natalie Morales (from left)",
-          "lang": "en"
-        },
-        "uri": "assets/p184072_ce_h7_aa.jpg",
-        "category": "Cast Ensemble",
-        "text": "no",
-        "primary": "true",
-        "tier": "Series"
-      },
-      {
-        "width": "270",
-        "height": "360",
-        "caption": {
-          "content": "Natalie Morales",
-          "lang": "en"
-        },
-        "uri": "assets/p184072_n510264_cc_v3_aa.jpg",
-        "size": "Md",
-        "aspect": "3x4",
-        "category": "Cast in Character",
-        "text": "no",
-        "primary": "true",
-        "tier": "Series"
-      },
-      {
-        "width": "135",
-        "height": "180",
-        "caption": {
-          "content": "Tamron Hall",
-          "lang": "en"
-        },
-        "uri": "assets/p184072_n611305_cc_v2_aa.jpg",
-        "size": "Sm",
-        "aspect": "3x4",
-        "category": "Cast in Character",
-        "text": "no",
-        "primary": "true",
-        "tier": "Series"
-      },
-      {
-        "width": "135",
-        "height": "180",
-        "caption": {
-          "content": "Kathie Lee Gifford",
-          "lang": "en"
-        },
-        "uri": "assets/p184072_n634_cc_v2_aa.jpg",
-        "size": "Sm",
-        "aspect": "3x4",
-        "category": "Cast in Character",
-        "text": "no",
-        "primary": "true",
-        "tier": "Series"
-      },
-      {
-        "width": "270",
-        "height": "360",
-        "caption": {
-          "content": "Kathie Lee Gifford",
-          "lang": "en"
-        },
-        "uri": "assets/p184072_n634_cc_v3_aa.jpg",
-        "size": "Md",
-        "aspect": "3x4",
-        "category": "Cast in Character",
-        "text": "no",
-        "primary": "true",
-        "tier": "Series"
-      },
-      {
-        "width": "540",
-        "height": "720",
-        "caption": {
-          "content": "Savannah Guthrie",
-          "lang": "en"
-        },
-        "uri": "assets/p184072_n589857_cc_v4_aa.jpg",
-        "size": "Lg",
-        "aspect": "3x4",
-        "category": "Cast in Character",
-        "text": "no",
-        "primary": "true",
-        "tier": "Series"
-      },
-      {
-        "width": "135",
-        "height": "180",
-        "caption": {
-          "content": "Al Roker",
-          "lang": "en"
-        },
-        "uri": "assets/p184072_n69061_cc_v2_aa.jpg",
-        "size": "Sm",
-        "aspect": "3x4",
-        "category": "Cast in Character",
-        "text": "no",
-        "primary": "true",
-        "tier": "Series"
-      },
-      {
-        "width": "270",
-        "height": "360",
-        "caption": {
-          "content": "Matt Lauer",
-          "lang": "en"
-        },
-        "uri": "assets/p184072_n70280_cc_v3_aa.jpg",
-        "size": "Md",
-        "aspect": "3x4",
-        "category": "Cast in Character",
-        "text": "no",
-        "primary": "true",
-        "tier": "Series"
-      },
-      {
-        "width": "540",
-        "height": "720",
-        "caption": {
-          "content": "Tamron Hall",
-          "lang": "en"
-        },
-        "uri": "assets/p184072_n611305_cc_v4_aa.jpg",
-        "size": "Lg",
-        "aspect": "3x4",
-        "category": "Cast in Character",
-        "text": "no",
-        "primary": "true",
-        "tier": "Series"
-      },
-      {
-        "width": "540",
-        "height": "720",
-        "caption": {
-          "content": "Natalie Morales",
-          "lang": "en"
-        },
-        "uri": "assets/p184072_n510264_cc_v4_aa.jpg",
-        "size": "Lg",
-        "aspect": "3x4",
-        "category": "Cast in Character",
-        "text": "no",
-        "primary": "true",
-        "tier": "Series"
-      },
-      {
-        "width": "270",
-        "height": "360",
-        "caption": {
-          "content": "Savannah Guthrie",
-          "lang": "en"
-        },
-        "uri": "assets/p184072_n589857_cc_v3_aa.jpg",
-        "size": "Md",
-        "aspect": "3x4",
-        "category": "Cast in Character",
-        "text": "no",
-        "primary": "true",
-        "tier": "Series"
-      },
-      {
-        "width": "270",
-        "height": "360",
-        "caption": {
-          "content": "Willie Geist",
-          "lang": "en"
-        },
-        "uri": "assets/p184072_n554890_cc_v3_aa.jpg",
-        "size": "Md",
-        "aspect": "3x4",
-        "category": "Cast in Character",
-        "text": "no",
-        "primary": "true",
-        "tier": "Series"
-      },
-      {
-        "width": "540",
-        "height": "720",
-        "caption": {
-          "content": "Al Roker",
-          "lang": "en"
-        },
-        "uri": "assets/p184072_n69061_cc_v4_aa.jpg",
-        "size": "Lg",
-        "aspect": "3x4",
-        "category": "Cast in Character",
-        "text": "no",
-        "primary": "true",
-        "tier": "Series"
-      },
-      {
-        "width": "135",
-        "height": "180",
-        "caption": {
-          "content": "Willie Geist",
-          "lang": "en"
-        },
-        "uri": "assets/p184072_n554890_cc_v2_aa.jpg",
-        "size": "Sm",
-        "aspect": "3x4",
-        "category": "Cast in Character",
-        "text": "no",
-        "primary": "true",
-        "tier": "Series"
-      },
-      {
-        "width": "540",
-        "height": "720",
-        "caption": {
-          "content": "Carson Daly",
-          "lang": "en"
-        },
-        "uri": "assets/p184072_n173491_cc_v4_aa.jpg",
-        "size": "Lg",
-        "aspect": "3x4",
-        "category": "Cast in Character",
-        "text": "no",
-        "primary": "true",
-        "tier": "Series"
-      },
-      {
-        "width": "720",
-        "height": "540",
-        "caption": {
-          "content": "Al Roker, Savannah Guthrie, Matt Lauer and Natalie Morales (from left)",
-          "lang": "en"
-        },
-        "uri": "assets/p184072_ce_h6_aa.jpg",
-        "size": "Lg",
-        "aspect": "4x3",
-        "category": "Cast Ensemble",
-        "text": "no",
-        "primary": "true",
-        "tier": "Series"
-      },
-      {
-        "width": "135",
-        "height": "180",
-        "caption": {
-          "content": "Savannah Guthrie",
-          "lang": "en"
-        },
-        "uri": "assets/p184072_n589857_cc_v2_aa.jpg",
-        "size": "Sm",
-        "aspect": "3x4",
-        "category": "Cast in Character",
-        "text": "no",
-        "primary": "true",
-        "tier": "Series"
-      },
-      {
-        "width": "270",
-        "height": "360",
-        "caption": {
-          "content": "Tamron Hall",
-          "lang": "en"
-        },
-        "uri": "assets/p184072_n611305_cc_v3_aa.jpg",
-        "size": "Md",
-        "aspect": "3x4",
-        "category": "Cast in Character",
-        "text": "no",
-        "primary": "true",
-        "tier": "Series"
-      },
-      {
-        "width": "135",
-        "height": "180",
-        "caption": {
-          "content": "Matt Lauer",
-          "lang": "en"
-        },
-        "uri": "assets/p184072_n70280_cc_v2_aa.jpg",
-        "size": "Sm",
-        "aspect": "3x4",
-        "category": "Cast in Character",
-        "text": "no",
-        "primary": "true",
-        "tier": "Series"
-      },
-      {
-        "width": "270",
-        "height": "360",
-        "caption": {
-          "content": "Al Roker",
-          "lang": "en"
-        },
-        "uri": "assets/p184072_n69061_cc_v3_aa.jpg",
-        "size": "Md",
-        "aspect": "3x4",
-        "category": "Cast in Character",
-        "text": "no",
-        "primary": "true",
-        "tier": "Series"
-      },
-      {
-        "width": "135",
-        "height": "180",
-        "caption": {
-          "content": "Carson Daly",
-          "lang": "en"
-        },
-        "uri": "assets/p184072_n173491_cc_v2_aa.jpg",
-        "size": "Sm",
-        "aspect": "3x4",
-        "category": "Cast in Character",
-        "text": "no",
-        "primary": "true",
-        "tier": "Series"
-      },
-      {
-        "width": "360",
-        "height": "270",
-        "uri": "https://s3.amazonaws.com/schedulesdirect/assets/p184072_l_h3_ab.jpg",
-        "size": "Md",
-        "aspect": "4x3",
-        "category": "Logo",
-        "text": "yes",
-        "primary": "true",
-        "tier": "Series"
-      },
-      {
-        "width": "180",
-        "height": "135",
-        "uri": "https://s3.amazonaws.com/schedulesdirect/assets/p184072_l_h5_ab.jpg",
-        "size": "Sm",
-        "aspect": "4x3",
-        "category": "Logo",
-        "text": "yes",
-        "primary": "true",
-        "tier": "Series"
-      },
-      {
         "width": "1920",
         "height": "1080",
-        "uri": "https://s3.amazonaws.com/schedulesdirect/assets/p184072_b_h10_ad.jpg",
+        "uri": "assets/p10949089_b_h10_aa.jpg",
         "size": "Ms",
         "aspect": "16x9",
         "category": "Banner-L1",
@@ -512,7 +16,7 @@
       {
         "width": "1280",
         "height": "720",
-        "uri": "assets/p184072_b_h11_ad.jpg",
+        "uri": "assets/p10949089_b_h11_aa.jpg",
         "size": "Lg",
         "aspect": "16x9",
         "category": "Banner-L1",
@@ -523,7 +27,7 @@
       {
         "width": "960",
         "height": "540",
-        "uri": "https://s3.amazonaws.com/schedulesdirect/assets/p184072_b_h12_ad.jpg",
+        "uri": "assets/p10949089_b_h12_aa.jpg",
         "size": "Md",
         "aspect": "16x9",
         "category": "Banner-L1",
@@ -534,7 +38,7 @@
       {
         "width": "480",
         "height": "270",
-        "uri": "assets/p184072_b_h13_ad.jpg",
+        "uri": "https://s3.amazonaws.com/schedulesdirect/assets/p10949089_b_h13_aa.jpg",
         "size": "Sm",
         "aspect": "16x9",
         "category": "Banner-L1",
@@ -545,7 +49,7 @@
       {
         "width": "240",
         "height": "135",
-        "uri": "assets/p184072_b_h14_ad.jpg",
+        "uri": "assets/p10949089_b_h14_aa.jpg",
         "size": "Xs",
         "aspect": "16x9",
         "category": "Banner-L1",
@@ -556,7 +60,7 @@
       {
         "width": "360",
         "height": "270",
-        "uri": "https://s3.amazonaws.com/schedulesdirect/assets/p184072_b_h3_ad.jpg",
+        "uri": "https://s3.amazonaws.com/schedulesdirect/assets/p10949089_b_h3_aa.jpg",
         "size": "Md",
         "aspect": "4x3",
         "category": "Banner-L1",
@@ -567,7 +71,7 @@
       {
         "width": "180",
         "height": "135",
-        "uri": "https://s3.amazonaws.com/schedulesdirect/assets/p184072_b_h5_ad.jpg",
+        "uri": "assets/p10949089_b_h5_aa.jpg",
         "size": "Sm",
         "aspect": "4x3",
         "category": "Banner-L1",
@@ -578,7 +82,7 @@
       {
         "width": "720",
         "height": "540",
-        "uri": "https://s3.amazonaws.com/schedulesdirect/assets/p184072_b_h6_ad.jpg",
+        "uri": "assets/p10949089_b_h6_aa.jpg",
         "size": "Lg",
         "aspect": "4x3",
         "category": "Banner-L1",
@@ -589,7 +93,7 @@
       {
         "width": "1440",
         "height": "1080",
-        "uri": "assets/p184072_b_h9_ad.jpg",
+        "uri": "assets/p10949089_b_h9_aa.jpg",
         "size": "Ms",
         "aspect": "4x3",
         "category": "Banner-L1",
@@ -600,7 +104,7 @@
       {
         "width": "135",
         "height": "180",
-        "uri": "assets/p184072_b_v2_ad.jpg",
+        "uri": "assets/p10949089_b_v2_aa.jpg",
         "size": "Sm",
         "aspect": "3x4",
         "category": "Banner-L1",
@@ -611,7 +115,7 @@
       {
         "width": "270",
         "height": "360",
-        "uri": "https://s3.amazonaws.com/schedulesdirect/assets/p184072_b_v3_ad.jpg",
+        "uri": "assets/p10949089_b_v3_aa.jpg",
         "size": "Md",
         "aspect": "3x4",
         "category": "Banner-L1",
@@ -622,7 +126,7 @@
       {
         "width": "540",
         "height": "720",
-        "uri": "assets/p184072_b_v4_ad.jpg",
+        "uri": "assets/p10949089_b_v4_aa.jpg",
         "size": "Lg",
         "aspect": "3x4",
         "category": "Banner-L1",
@@ -633,7 +137,7 @@
       {
         "width": "240",
         "height": "360",
-        "uri": "https://s3.amazonaws.com/schedulesdirect/assets/p184072_b_v5_ad.jpg",
+        "uri": "assets/p10949089_b_v5_aa.jpg",
         "size": "Md",
         "aspect": "2x3",
         "category": "Banner-L1",
@@ -644,7 +148,7 @@
       {
         "width": "120",
         "height": "180",
-        "uri": "https://s3.amazonaws.com/schedulesdirect/assets/p184072_b_v6_ad.jpg",
+        "uri": "assets/p10949089_b_v6_aa.jpg",
         "size": "Sm",
         "aspect": "2x3",
         "category": "Banner-L1",
@@ -655,7 +159,7 @@
       {
         "width": "480",
         "height": "720",
-        "uri": "https://s3.amazonaws.com/schedulesdirect/assets/p184072_b_v7_ad.jpg",
+        "uri": "assets/p10949089_b_v7_aa.jpg",
         "size": "Lg",
         "aspect": "2x3",
         "category": "Banner-L1",
@@ -666,7 +170,7 @@
       {
         "width": "960",
         "height": "1440",
-        "uri": "assets/p184072_b_v8_ad.jpg",
+        "uri": "assets/p10949089_b_v8_aa.jpg",
         "size": "Ms",
         "aspect": "2x3",
         "category": "Banner-L1",
@@ -677,7 +181,7 @@
       {
         "width": "1080",
         "height": "1440",
-        "uri": "assets/p184072_b_v9_ad.jpg",
+        "uri": "assets/p10949089_b_v9_aa.jpg",
         "size": "Ms",
         "aspect": "3x4",
         "category": "Banner-L1",
@@ -688,7 +192,7 @@
       {
         "width": "1920",
         "height": "1080",
-        "uri": "https://s3.amazonaws.com/schedulesdirect/assets/p184072_i_h10_ab.jpg",
+        "uri": "assets/p10949089_i_h10_aa.jpg",
         "size": "Ms",
         "aspect": "16x9",
         "category": "Iconic",
@@ -699,7 +203,7 @@
       {
         "width": "1280",
         "height": "720",
-        "uri": "assets/p184072_i_h11_ab.jpg",
+        "uri": "assets/p10949089_i_h11_aa.jpg",
         "size": "Lg",
         "aspect": "16x9",
         "category": "Iconic",
@@ -710,7 +214,7 @@
       {
         "width": "960",
         "height": "540",
-        "uri": "https://s3.amazonaws.com/schedulesdirect/assets/p184072_i_h12_ab.jpg",
+        "uri": "assets/p10949089_i_h12_aa.jpg",
         "size": "Md",
         "aspect": "16x9",
         "category": "Iconic",
@@ -721,7 +225,7 @@
       {
         "width": "480",
         "height": "270",
-        "uri": "https://s3.amazonaws.com/schedulesdirect/assets/p184072_i_h13_ab.jpg",
+        "uri": "assets/p10949089_i_h13_aa.jpg",
         "size": "Sm",
         "aspect": "16x9",
         "category": "Iconic",
@@ -732,7 +236,7 @@
       {
         "width": "240",
         "height": "135",
-        "uri": "assets/p184072_i_h14_ab.jpg",
+        "uri": "assets/p10949089_i_h14_aa.jpg",
         "size": "Xs",
         "aspect": "16x9",
         "category": "Iconic",
@@ -743,7 +247,7 @@
       {
         "width": "360",
         "height": "270",
-        "uri": "https://s3.amazonaws.com/schedulesdirect/assets/p184072_i_h3_ab.jpg",
+        "uri": "assets/p10949089_i_h3_aa.jpg",
         "size": "Md",
         "aspect": "4x3",
         "category": "Iconic",
@@ -754,7 +258,7 @@
       {
         "width": "180",
         "height": "135",
-        "uri": "https://s3.amazonaws.com/schedulesdirect/assets/p184072_i_h5_ab.jpg",
+        "uri": "assets/p10949089_i_h5_aa.jpg",
         "size": "Sm",
         "aspect": "4x3",
         "category": "Iconic",
@@ -765,7 +269,7 @@
       {
         "width": "720",
         "height": "540",
-        "uri": "assets/p184072_i_h6_ab.jpg",
+        "uri": "assets/p10949089_i_h6_aa.jpg",
         "size": "Lg",
         "aspect": "4x3",
         "category": "Iconic",
@@ -776,7 +280,7 @@
       {
         "width": "1440",
         "height": "1080",
-        "uri": "assets/p184072_i_h9_ab.jpg",
+        "uri": "assets/p10949089_i_h9_aa.jpg",
         "size": "Ms",
         "aspect": "4x3",
         "category": "Iconic",
@@ -787,7 +291,7 @@
       {
         "width": "135",
         "height": "180",
-        "uri": "assets/p184072_i_v2_ab.jpg",
+        "uri": "assets/p10949089_i_v2_aa.jpg",
         "size": "Sm",
         "aspect": "3x4",
         "category": "Iconic",
@@ -798,7 +302,7 @@
       {
         "width": "270",
         "height": "360",
-        "uri": "assets/p184072_i_v3_ab.jpg",
+        "uri": "assets/p10949089_i_v3_aa.jpg",
         "size": "Md",
         "aspect": "3x4",
         "category": "Iconic",
@@ -809,7 +313,7 @@
       {
         "width": "540",
         "height": "720",
-        "uri": "assets/p184072_i_v4_ab.jpg",
+        "uri": "assets/p10949089_i_v4_aa.jpg",
         "size": "Lg",
         "aspect": "3x4",
         "category": "Iconic",
@@ -820,7 +324,7 @@
       {
         "width": "240",
         "height": "360",
-        "uri": "assets/p184072_i_v5_ab.jpg",
+        "uri": "assets/p10949089_i_v5_aa.jpg",
         "size": "Md",
         "aspect": "2x3",
         "category": "Iconic",
@@ -831,7 +335,7 @@
       {
         "width": "120",
         "height": "180",
-        "uri": "https://s3.amazonaws.com/schedulesdirect/assets/p184072_i_v6_ab.jpg",
+        "uri": "assets/p10949089_i_v6_aa.jpg",
         "size": "Sm",
         "aspect": "2x3",
         "category": "Iconic",
@@ -842,7 +346,7 @@
       {
         "width": "480",
         "height": "720",
-        "uri": "https://s3.amazonaws.com/schedulesdirect/assets/p184072_i_v7_ab.jpg",
+        "uri": "assets/p10949089_i_v7_aa.jpg",
         "size": "Lg",
         "aspect": "2x3",
         "category": "Iconic",
@@ -853,7 +357,7 @@
       {
         "width": "960",
         "height": "1440",
-        "uri": "assets/p184072_i_v8_ab.jpg",
+        "uri": "assets/p10949089_i_v8_aa.jpg",
         "size": "Ms",
         "aspect": "2x3",
         "category": "Iconic",
@@ -864,7 +368,7 @@
       {
         "width": "1080",
         "height": "1440",
-        "uri": "assets/p184072_i_v9_ab.jpg",
+        "uri": "assets/p10949089_i_v9_aa.jpg",
         "size": "Ms",
         "aspect": "3x4",
         "category": "Iconic",


### PR DESCRIPTION
When you have two (or more) servers competing for a token from Schedules Direct (you can only have one per account), they could end up mostly in sync with their request frequencies, so I added to the two methods used most when downloading guide data to wait a random timeout when the token unexpectedly expires before getting a new one.

This also cleans up some image processing assumptions that have proven to be less than reliable. After pouring over a lot of data that the kinds of images we are looking for to place in Show objects only appear in programs that are movies, so now we don't even try to get any images if the program is a series since the images will not be specific to that episode and the one image that will be is tall instead of wide which makes it awkward and somewhat useless.

The category Movie is now always present as the first category for all Show objects that have an ID starting with MV.

I bumped up the minor version because we have released installers for the last minor version and this creates issues for the Windows installer when we do not increment the version.