### PR TITLE
Fixes a NPE that happens in some coditions

### DIFF
--- a/java/sage/LinuxUtils.java
+++ b/java/sage/LinuxUtils.java
@@ -561,7 +561,7 @@ public class LinuxUtils
     "inet addr\\:(\\p{Digit}\\p{Digit}?\\p{Digit}?\\.\\p{Digit}\\p{Digit}?\\p{Digit}?\\.\\p{Digit}\\p{Digit}?\\p{Digit}?\\.\\p{Digit}\\p{Digit}?\\p{Digit}?) ");
 
   static String getIPAddressFromInetInfo(String inetInfo) {
-    if (inetInfo.contains("UP"))
+    if (inetInfo!=null && inetInfo.contains("UP"))
     {
       java.util.regex.Matcher mat = INETINFO_IP_PATTERN.matcher(inetInfo);
       // Go with eth1

--- a/java/sage/LinuxUtils.java
+++ b/java/sage/LinuxUtils.java
@@ -15,6 +15,10 @@
  */
 package sage;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 public class LinuxUtils
 {
   public static final String NET_CONFIG_WIRED = "linux/network/wired";
@@ -537,24 +541,36 @@ public class LinuxUtils
     // We can't enumerate the network interfaces because it also includes interfaces
     // that are down. So this might not be are actual IP. The only way we can do it
     // is using ifconfig or native code. This can't be done correctly in Java.
-    String eth0Info = IOUtils.exec(new String[] { "ifconfig", "eth0" });
-    String eth1Info = IOUtils.exec(new String[] { "ifconfig", "eth1" });
-    java.util.regex.Pattern pat = java.util.regex.Pattern.compile(
-        "inet addr\\:(\\p{Digit}\\p{Digit}?\\p{Digit}?\\.\\p{Digit}\\p{Digit}?\\p{Digit}?\\.\\p{Digit}\\p{Digit}?\\p{Digit}?\\.\\p{Digit}\\p{Digit}?\\p{Digit}?) ");
-    if (eth1Info.indexOf("UP") != -1)
+
+    // List of "known" linux network addresses
+    // adding the "configured" one first, may result is 2 hits on that one if it's wrong, and it's
+    // in the extended list
+    List<String> devices = new ArrayList<>(Arrays.asList(Sage.get("linux/wired_network_port", "eth0"), "eth0","eth1","eno1","br0","docker0"));
+    String ip=null;
+    for (String dev: devices)
     {
-      java.util.regex.Matcher mat = pat.matcher(eth1Info);
+      ip=getIPAddressFromInetInfo(IOUtils.exec(new String[] { "ifconfig", dev }));
+      if (ip!=null) return ip;
+    }
+
+    System.out.println("Linux: Unable to get IP ADDRESS from " + devices);
+    return "0.0.0.0";
+  }
+
+  static java.util.regex.Pattern INETINFO_IP_PATTERN = java.util.regex.Pattern.compile(
+    "inet addr\\:(\\p{Digit}\\p{Digit}?\\p{Digit}?\\.\\p{Digit}\\p{Digit}?\\p{Digit}?\\.\\p{Digit}\\p{Digit}?\\p{Digit}?\\.\\p{Digit}\\p{Digit}?\\p{Digit}?) ");
+
+  static String getIPAddressFromInetInfo(String inetInfo) {
+    if (inetInfo.contains("UP"))
+    {
+      java.util.regex.Matcher mat = INETINFO_IP_PATTERN.matcher(inetInfo);
       // Go with eth1
-      mat.find();
-      return mat.group(1);
+      if (mat.find())
+      {
+        return mat.group(1);
+      }
     }
-    else
-    {
-      java.util.regex.Matcher mat = pat.matcher(eth0Info);
-      // Go with eth0
-      mat.find();
-      return mat.group(1);
-    }
+    return null;
   }
 
   public static int getOpticalDiscType()

--- a/test/java/sage/LinuxUtilsTest.java
+++ b/test/java/sage/LinuxUtilsTest.java
@@ -40,5 +40,8 @@ public class LinuxUtilsTest
       "          collisions:0 txqueuelen:1000 \n" +
       "          RX bytes:3960802559 (3.9 GB)  TX bytes:23567094632 (23.5 GB)\n";
     assertNull(LinuxUtils.getIPAddressFromInetInfo(inetinfo3));
+
+    // null should not fail with NPE but return null
+    assertNull(LinuxUtils.getIPAddressFromInetInfo(null));
   }
 }

--- a/test/java/sage/LinuxUtilsTest.java
+++ b/test/java/sage/LinuxUtilsTest.java
@@ -1,0 +1,44 @@
+package sage;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+/**
+ * Created by seans on 13/11/16.
+ */
+public class LinuxUtilsTest
+{
+  @Test
+  public void testGetIPAddressFromInetInfo() throws Exception
+  {
+    String inetinfo1 = "eno1      Link encap:Ethernet  HWaddr 10:c3:7b:91:3b:4d  \n" +
+      "          inet addr:192.168.1.192  Bcast:192.168.1.255  Mask:255.255.255.0\n" +
+      "          inet6 addr: fe80::7474:bd53:85aa:8f37/64 Scope:Link\n" +
+      "          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1\n" +
+      "          RX packets:56401450 errors:0 dropped:0 overruns:0 frame:0\n" +
+      "          TX packets:40678669 errors:0 dropped:0 overruns:0 carrier:0\n" +
+      "          collisions:0 txqueuelen:1000 \n" +
+      "          RX bytes:33436572650 (33.4 GB)  TX bytes:11772048166 (11.7 GB)\n" +
+      "          Interrupt:20 Memory:ef300000-ef320000";
+    assertEquals("192.168.1.192", LinuxUtils.getIPAddressFromInetInfo(inetinfo1));
+
+    String inetinfo2 = "br0       Link encap:Ethernet  HWaddr 94:de:80:01:64:bb  \n" +
+      "          inet addr:192.168.1.10  Bcast:0.0.0.0  Mask:255.255.255.0\n" +
+      "          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1\n" +
+      "          RX packets:10641514 errors:0 dropped:64937 overruns:0 frame:0\n" +
+      "          TX packets:17523316 errors:0 dropped:0 overruns:0 carrier:0\n" +
+      "          collisions:0 txqueuelen:1000 \n" +
+      "          RX bytes:3721981747 (3.7 GB)  TX bytes:23565332718 (23.5 GB)\n";
+    assertEquals("192.168.1.10", LinuxUtils.getIPAddressFromInetInfo(inetinfo2));
+
+    // no IP on this one, but it is UP, but should return null
+    String inetinfo3 = "eth0      Link encap:Ethernet  HWaddr 94:de:80:01:64:bb  \n" +
+      "          UP BROADCAST RUNNING SLAVE MULTICAST  MTU:1500  Metric:1\n" +
+      "          RX packets:11966319 errors:0 dropped:0 overruns:0 frame:0\n" +
+      "          TX packets:17523316 errors:0 dropped:0 overruns:0 carrier:0\n" +
+      "          collisions:0 txqueuelen:1000 \n" +
+      "          RX bytes:3960802559 (3.9 GB)  TX bytes:23567094632 (23.5 GB)\n";
+    assertNull(LinuxUtils.getIPAddressFromInetInfo(inetinfo3));
+  }
+}


### PR DESCRIPTION
When the IP address can't be determined (ie, not using eth0 or eth1) you get a NPE.   This fixes the NPE, but also adds ent1 br0 and docker0 to the list of devices to check for IP address.  The code will iterate all those devices looking for the first one that returns an address.