### PR TITLE
Fixes deadlock in the Plugin Manager

### DIFF
--- a/java/sage/Version.java
+++ b/java/sage/Version.java
@@ -23,7 +23,7 @@ public class Version
 {
   public static final byte MAJOR_VERSION = 9;
   public static final byte MINOR_VERSION = 0;
-  public static final byte MICRO_VERSION = 10;
+  public static final byte MICRO_VERSION = 11;
 
   public static final String VERSION = MAJOR_VERSION + "." + MINOR_VERSION + "." + MICRO_VERSION + "." + SageConstants.BUILD_VERSION;
 

--- a/test/java/sage/plugin/PluginEventManagerTest.java
+++ b/test/java/sage/plugin/PluginEventManagerTest.java
@@ -1,0 +1,50 @@
+package sage.plugin;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import sage.SageTVEventListener;
+import sage.TestUtils;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.testng.Assert.*;
+
+/**
+ * Created by seans on 17/11/16.
+ */
+public class PluginEventManagerTest
+{
+  @BeforeClass
+  public void setup() throws Throwable
+  {
+    TestUtils.initializeSageTVForTesting();
+  }
+
+  @Test
+  public void testEventPost() throws InterruptedException
+  {
+    final AtomicBoolean eventHandled = new AtomicBoolean();
+    SageTVEventListener listener = new SageTVEventListener()
+    {
+      @Override
+      public void sageEvent(String eventName, Map eventVars)
+      {
+        System.out.println("Event was fired: " + eventName);
+        eventHandled.set(true);
+      }
+    };
+
+    PluginEventManager.getInstance().reset();
+    PluginEventManager.getInstance().startup();
+    PluginEventManager.getInstance().eventSubscribe(listener,"test_event");
+
+    // previously passing NULL map would cause error, and the event queue would be deadlocked
+    // this should now pass be handled correctly
+    PluginEventManager.getInstance().postEvent("test_event", null, false);
+
+    Thread.sleep(500);
+
+    assertTrue(eventHandled.get(), "Event was not handled");
+  }
+}


### PR DESCRIPTION
If the Plugin Manager experienced and error (ie, passed in null map), then the event that was being processed would never get cleaned up, and the queue would always look like it is busy.  This fix ensures that the queue gets cleaned up, and, that you can pass a null map.