### PR TITLE
Fixed so that Ministry will not allow sleep while converting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version 9.0.10 (??)
 * Fix: Enable streams with valid PAT packets and invalid PMT packets to be able to be detected by the built in remuxer.
 * New: Schedules Direct now includes teams as people for favorite scheduling.
+* New: SageTV server will no longer allow the server to go to sleep until video conversions are complete.
 
 ## Version 9.0.9 (2016-10-10)
 * Fix: GetSeriesID wasn't always returning a valid series ID

--- a/java/sage/Ministry.java
+++ b/java/sage/Ministry.java
@@ -830,7 +830,7 @@ public class Ministry implements Runnable
     // This is true if there's any transcode jobs are in the queue
     synchronized (this)
     {
-    	return (getTranscodeJobIDs().length > 0) ? true : false ;
+    	return (converting.size() > 0 || waitingForConversion.size() > 0);
     }
   }
   


### PR DESCRIPTION
As per #146, should now only look for queued and in progress jobs to prevent sleep.  Previously, any job in the list, including failed and completed jobs, were preventing sleep.