### PR TITLE
Fix to allow mounting DVD iso images as non-root

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import org.gradle.internal.os.OperatingSystem
 
 plugins {
-	id "com.jfrog.bintray" version "1.3.1"
+	id "com.jfrog.bintray" version "1.7.3"
 }
 
 apply plugin: "java"

--- a/java/sage/FSManager.java
+++ b/java/sage/FSManager.java
@@ -416,7 +416,7 @@ public class FSManager implements Runnable
           // mount requires root permissions
           // the sagetv user needs to be in the sudoers list
           // NOTE mount command is NOT resolved in properties because sudo is being used
-          if (IOUtils.exec2(new String[]{"sudo","mount", isoFile.getAbsolutePath(), mountDir.getAbsolutePath(), "-o", "loop,ro"}, true) != 0)
+          if (IOUtils.exec2(new String[]{"sudo","-n", "mount", isoFile.getAbsolutePath(), mountDir.getAbsolutePath(), "-o", "loop,ro"}, true) != 0)
           {
             if (Sage.DBG) System.out.println("FAILED mounting ISO image " + isoFile + " to " + mountDir);
             return null;
@@ -496,7 +496,7 @@ public class FSManager implements Runnable
         if (Sage.LINUX_IS_ROOT)
           IOUtils.exec2(new String[]{"umount", mountDir.getAbsolutePath()}, false);
         else
-          IOUtils.exec2(new String[]{"sudo","umount", mountDir.getAbsolutePath()}, false);
+          IOUtils.exec2(new String[]{"sudo", "-n", "umount", mountDir.getAbsolutePath()}, false);
       }
       mountDir.delete();
     }

--- a/java/sage/FSManager.java
+++ b/java/sage/FSManager.java
@@ -411,10 +411,24 @@ public class FSManager implements Runnable
       }
       else
       {
-        if (IOUtils.exec2(new String[] { Sage.get("linux/dvdmounter", "mount"), isoFile.getAbsolutePath(), mountDir.getAbsolutePath(), "-o", "loop" }, true) != 0)
+        if (!Sage.LINUX_IS_ROOT)
         {
-          if (Sage.DBG) System.out.println("FAILED mounting ISO image " + isoFile + " to " + mountDir);
-          return null;
+          // mount requires root permissions
+          // the sagetv user needs to be in the sudoers list
+          // NOTE mount command is NOT resolved in properties because sudo is being used
+          if (IOUtils.exec2(new String[]{"sudo","mount", isoFile.getAbsolutePath(), mountDir.getAbsolutePath(), "-o", "loop,ro"}, true) != 0)
+          {
+            if (Sage.DBG) System.out.println("FAILED mounting ISO image " + isoFile + " to " + mountDir);
+            return null;
+          }
+        }
+        else
+        {
+          if (IOUtils.exec2(new String[]{Sage.get("linux/dvdmounter", "mount"), isoFile.getAbsolutePath(), mountDir.getAbsolutePath(), "-o", "loop"}, true) != 0)
+          {
+            if (Sage.DBG) System.out.println("FAILED mounting ISO image " + isoFile + " to " + mountDir);
+            return null;
+          }
         }
       }
       return mountDir;
@@ -478,7 +492,12 @@ public class FSManager implements Runnable
         }
       }
       else
-        IOUtils.exec2(new String[] { "umount", mountDir.getAbsolutePath() }, false);
+      {
+        if (Sage.LINUX_IS_ROOT)
+          IOUtils.exec2(new String[]{"umount", mountDir.getAbsolutePath()}, false);
+        else
+          IOUtils.exec2(new String[]{"sudo","umount", mountDir.getAbsolutePath()}, false);
+      }
       mountDir.delete();
     }
   }

--- a/java/sage/Sage.java
+++ b/java/sage/Sage.java
@@ -86,6 +86,7 @@ public final class Sage
   static final boolean DISABLE_MSG_LOOP_FOR_JPROFILER = false;
   public static boolean WINDOWS_OS = false;
   public static boolean LINUX_OS = false;
+  public static boolean LINUX_IS_ROOT = false; // will be true if SageTV Linux is running as 'root'
   public static boolean MAC_OS_X = false;
   public static boolean VISTA_OS = false; // if this is true, then WINDOWS_OS is also true
   public static boolean EMBEDDED = false;
@@ -117,7 +118,7 @@ public final class Sage
     MAC_OS_X = System.getProperty("os.name").toLowerCase().indexOf("mac os x") != -1;
     LINUX_OS = !WINDOWS_OS && !MAC_OS_X;
     VISTA_OS = WINDOWS_OS && (System.getProperty("os.version").startsWith("6.") || System.getProperty("os.version").startsWith("7."));
-
+    LINUX_IS_ROOT = "root".equals(System.getProperty("user.name"));
     if (WINDOWS_OS)
       sage.Native.loadLibrary("SageTVWin32");
     else


### PR DESCRIPTION
This allows a non-root instance of sagetv to import a dvd iso (previously it would fail).   I'm unsure if there are other changes that would be required in order to actually play the dvd... but these changes do allow it to be imported.

There are many places in SageTV where "mount" is used... I'm thinking that a better long term solution might be to create a "Mount" class that manages the need for sudo, and then we find/replace all the exec "mount" (and "umount") places with a Mount class than can manage this.