### PR TITLE
Fixed saved country not being returned sometimes and the current region was always null. Removed the asterisks when entering the Schedules Direct password. Updated STV version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Change Log
 
-## Version 9.0.10 (??)
-* Fix: Enable streams with valid PAT packets and invalid PMT packets to be able to be detected by the built in remuxer.
+## Version 9.0.12 (??)
 * New: Schedules Direct now includes teams as people for favorite scheduling.
 * New: SageTV server will no longer allow the server to go to sleep until video conversions are complete.
+* Fix: Schedules Direct was not returning the saved country in some cases.
+* Fix: Removed asterisks from password field when entering the password for Schedules Direct.
+
+## Version 9.0.11 (2016-11-20)
+* Fix: Enable streams with valid PAT packets and invalid PMT packets to be able to be detected by the built in remuxer.
+* Fix: Linux tries a few more adapters when trying to get the primary server IP address.
 
 ## Version 9.0.9 (2016-10-10)
 * Fix: GetSeriesID wasn't always returning a valid series ID

--- a/java/sage/Version.java
+++ b/java/sage/Version.java
@@ -23,7 +23,7 @@ public class Version
 {
   public static final byte MAJOR_VERSION = 9;
   public static final byte MINOR_VERSION = 0;
-  public static final byte MICRO_VERSION = 11;
+  public static final byte MICRO_VERSION = 12;
 
   public static final String VERSION = MAJOR_VERSION + "." + MINOR_VERSION + "." + MICRO_VERSION + "." + SageConstants.BUILD_VERSION;
 


### PR DESCRIPTION
NTE has been confusing lots of forum members, especial with the password field in Schedules Direct. It has been requested by numerous members to have the asterisks removed. I personally do not like to see my password in full view of everyone around me even if technically they might be following what I am typing in with NTE, it's definitely harder for most people to reconstruct your password that way. Because of this and I'm sure at least one person will ask if this is possible, I added an option to enable or disable hiding of the password. It defaults to show the password.

There was also an oversight in the STV for Schedules Direct. The method was expecting to be told what region to verify the saved country against, but the region was always null causing the first country for the saved region to always be selected.

I incremented the STV version to the next release number.

I also fixed the change log because somehow we went from .9 to .11 and .10 was never built. It also contained some changes that were definitely not in the .11 distribution.