### PR TITLE
Fixed parsing of regex for postal codes and added duplicate lineup name support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Version 9.0.13 (??)
+* Fix: Schedules Direct was unable to distinguish between two lineups with the exact same name.
+* Fix: Schedules Direct was using an unknown regular expression for the postal code. The code also now skips the check if it does not recognize the regex formatting.
+
 ## Version 9.0.12 (2016-12-22)
 * New: Schedules Direct now includes teams as people for favorite scheduling.
 * New: SageTV server will no longer allow the server to go to sleep until video conversions are complete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Version 9.0.13 (??)
 * Fix: Schedules Direct was unable to distinguish between two lineups with the exact same name.
-* Fix: Schedules Direct was using an unknown regular expression for the postal code. The code also now skips the check if it does not recognize the regex formatting.
+* Fix: Added handling for an unknown regular expression Schedules Direct was providing for the postal code for a few countries. The code also now skips the check if it does not recognize the regex formatting.
 
 ## Version 9.0.12 (2016-12-22)
 * New: Schedules Direct now includes teams as people for favorite scheduling.


### PR DESCRIPTION
An issue recently came up in the forums that revealed that it was possible to have more than one lineup have the exact same name. This code adds the unique code associated with every lineup if there is a duplicate within the returned lineups.

Also recently it appears that at least Canada is using additional characters in the provided regex, so things were changed to remove the starting / and the last / as long as at least one character is in between them. That formatting works fine for JavaScript, but not for Java. Also, so that this is less of a burden on users in the future, if the regex isn't formatted in an expected way, it will just say that it passed. This feature is really just to make users more aware of when they make a mistake and doesn't really serve a greater purpose.