### PR TITLE
Retain prepended zeros if the channel  number is 4 digits (including the zeros).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * public boolean[] IsSDEPGInProgressSport(String[] ExternalIDs);
   * public int[] GetSDEPGInProgressSportStatus(String[] ExternalIDs);
 * New: Added editorials based on recommendations from Schedules Direct.
+* Fix: Radio stations in Schedules Direct guide data now retain their prepended zeros in the guide data.
 
 ## Version 9.0.13 (2017-01-19)
 * Fix: Schedules Direct was unable to distinguish between two lineups with the exact same name.

--- a/java/sage/epg/sd/SDUtils.java
+++ b/java/sage/epg/sd/SDUtils.java
@@ -371,6 +371,11 @@ public class SDUtils
 
   public static String removeLeadingZeros(String channelNumber)
   {
+    // Radio stations have 4 zeros total and without these, we can't distinguish between them and
+    // normal channels, so we always leave those alone.
+    if (channelNumber.length() == 4 && channelNumber.startsWith("0"))
+      return channelNumber;
+
     char channel[] = channelNumber.toCharArray();
     int writeFrom = -1;
 

--- a/test/java/sage/epg/sd/SDUtilsTest.java
+++ b/test/java/sage/epg/sd/SDUtilsTest.java
@@ -66,6 +66,9 @@ public class SDUtilsTest
     assert "100".equals(cleaned) : "Expected 100, got " + cleaned;
     cleaned = SDUtils.removeLeadingZeros("1000");
     assert "1000".equals(cleaned) : "Expected 1000, got " + cleaned;
+    // Radio channels should not be trimmed.
+    cleaned = SDUtils.removeLeadingZeros("0000");
+    assert "0000".equals(cleaned) : "Expected 0000, got " + cleaned;
   }
 
   @Test(groups = {"gson", "schedulesDirect", "program", "conversion" })


### PR DESCRIPTION
This is needed because radio stations would otherwise have the exact same channel numbers as normal channels.