### PR TITLE
Some Schedules Direct missing station improvements.

### DIFF
--- a/java/sage/Wizard.java
+++ b/java/sage/Wizard.java
@@ -64,6 +64,7 @@ import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.net.Socket;
 import java.text.DateFormat;
+import java.text.DecimalFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/java/sage/Wizard.java
+++ b/java/sage/Wizard.java
@@ -796,7 +796,7 @@ public class Wizard implements EPGDBPublic2
    */
   public boolean isNoShow(Airing testMe)
   {
-    return testMe != null && testMe.getShowID() == noShowID;
+    return testMe != null && testMe.showID == noShowID;
   }
 
   void mpause() { if (primed) { try{Thread.sleep(Sage.EMBEDDED ? 300 : 50);}catch(Exception e){} } }

--- a/java/sage/epg/sd/json/programs/SDDescriptions.java
+++ b/java/sage/epg/sd/json/programs/SDDescriptions.java
@@ -51,9 +51,10 @@ public class SDDescriptions
    * The long description if available will always be preferred over the short description.
    *
    * @param language The desired language abbreviation. (Ex. en for English)
+   * @param forceDesiredLanguage If the desired language is not available, a blank English
    * @return An available description or <code>null</code> if no descriptions exist.
    */
-  public Description getDescription(String language)
+  public Description getDescription(String language, boolean forceDesiredLanguage)
   {
     if (description1000 == null || description1000.length == 0)
     {
@@ -66,7 +67,7 @@ public class SDDescriptions
           return desc;
       }
 
-      return description100[0];
+      return forceDesiredLanguage ? BLANK_DESCRIPTION : description100[0];
     }
 
     for (Description desc : description1000)
@@ -84,7 +85,7 @@ public class SDDescriptions
       }
     }
 
-    return description1000[0];
+    return forceDesiredLanguage ? BLANK_DESCRIPTION : description1000[0];
   }
 
   public Description getFirstDescription()


### PR DESCRIPTION
It turns out that sometimes some airings actually do end up being found using the method we added to the Wizard and this prevents the station from being invalidated and re-downloaded. I changed it to just check for an airing at this exact time and if it doesn't exist or is a No Data airing, we invalidate the station. This is also based more strongly on data we need now instead of data we have now.

I also added some methods I added for Seeker2 to create timed/manual recordings because I really didn't like the idea of creating an airing outside of the Wizard within Seeker. It just feels like the wrong place to do this. I'm not ready to commit the Seeker2 core changes yet since I'm still slowly working out a few small, but known issues.