### PR TITLE
Create new API, GetPotentialFavoriteAirings

### DIFF
--- a/java/sage/Agent.java
+++ b/java/sage/Agent.java
@@ -442,12 +442,12 @@ public class Agent extends DBObject implements Favorite
   }
 
   public synchronized Airing[] getRelatedAirings(DBObject[] allAirs, boolean mainCache, boolean controlCPUUsage,
-          boolean ignoreDisabled, StringBuffer sbCache)
+          boolean ignoreDisabledFlag, StringBuffer sbCache)
   {
     if (allAirs == null) return Pooler.EMPTY_AIRING_ARRAY;
 
     //Short circuit this if the agent is disabled (and we don't want to ignore that fact)
-    if(!ignoreDisabled && testAgentFlag(DISABLED_FLAG)) return Pooler.EMPTY_AIRING_ARRAY;
+    if(!ignoreDisabledFlag && testAgentFlag(DISABLED_FLAG)) return Pooler.EMPTY_AIRING_ARRAY;
 
     if (ENABLE_AGENT_AIRING_CACHE)
     {
@@ -474,7 +474,7 @@ public class Agent extends DBObject implements Favorite
       for (Show show : shows) {
         Airing[] airings = wiz.getAirings(show, 0);
         for(Airing a : airings) {
-          if (followsTrend(a, true, sbCache, true, true))
+          if (followsTrend(a, true, sbCache, true, ignoreDisabledFlag))
             rv.add(a);
         }
       }
@@ -483,7 +483,7 @@ public class Agent extends DBObject implements Favorite
       {
         Airing a = (Airing) allAirs[i];
         if (a == null) continue;
-        if (followsTrend(a, true, sbCache, false, true))
+        if (followsTrend(a, true, sbCache, false, ignoreDisabledFlag))
           rv.add(a);
         if ((i % CPU_CONTROL_MOD_COUNT) == 0 && controlCPUUsage)
           try{Thread.sleep(Carny.SLEEP_PERIOD);}catch(Exception e){}
@@ -593,7 +593,7 @@ public class Agent extends DBObject implements Favorite
    * the buffer will be cleared and use.  When calling this method in a loop, the same StringBuffer can be used for each
    * call to limit object creation and memory use.
    * @param skipKeyword If true, keyword matching is not considered
-   * @param ignoreDisabled If true, treat this agent as if it is enabled, even if it isn't.
+   * @param ignoreDisabledFlag If true, treat this agent as if it is enabled, even if it isn't.
    * @return true if the given Airing matches this Agent (given the parameter criteria) , false otherwise.
    */
   /*
@@ -601,14 +601,14 @@ public class Agent extends DBObject implements Favorite
    * tested; but we can have Lucene do this for us
    */
   public boolean followsTrend(Airing air, boolean mustBeViewable, StringBuffer sbCache, boolean skipKeyword,
-          boolean ignoreDisabled)
+          boolean ignoreDisabledFlag)
   {
     if (air == null) return false;
     Show s = air.getShow();
     if (s == null) return false;
 
     //A disabled agent doesn't match any airings
-    if(!ignoreDisabled && testAgentFlag(DISABLED_FLAG))
+    if(!ignoreDisabledFlag && testAgentFlag(DISABLED_FLAG))
         return false;
     // Do not be case sensitive when checking titles!! We got a bunch of complaints about this on our forums.
     // Don't let null titles match all the Favorites!

--- a/java/sage/Agent.java
+++ b/java/sage/Agent.java
@@ -438,7 +438,16 @@ public class Agent extends DBObject implements Favorite
   public synchronized Airing[] getRelatedAirings(DBObject[] allAirs, boolean mainCache, boolean controlCPUUsage,
       StringBuffer sbCache)
   {
+      return getRelatedAirings(allAirs, mainCache, controlCPUUsage, false, sbCache);
+  }
+
+  public synchronized Airing[] getRelatedAirings(DBObject[] allAirs, boolean mainCache, boolean controlCPUUsage,
+          boolean ignoreDisabled, StringBuffer sbCache)
+  {
     if (allAirs == null) return Pooler.EMPTY_AIRING_ARRAY;
+
+    //Short circuit this if the agent is disabled (and we don't want to ignore that fact)
+    if(!ignoreDisabled && testAgentFlag(DISABLED_FLAG)) return Pooler.EMPTY_AIRING_ARRAY;
 
     if (ENABLE_AGENT_AIRING_CACHE)
     {
@@ -465,7 +474,7 @@ public class Agent extends DBObject implements Favorite
       for (Show show : shows) {
         Airing[] airings = wiz.getAirings(show, 0);
         for(Airing a : airings) {
-          if (followsTrend(a, true, sbCache, true))
+          if (followsTrend(a, true, sbCache, true, true))
             rv.add(a);
         }
       }
@@ -474,7 +483,7 @@ public class Agent extends DBObject implements Favorite
       {
         Airing a = (Airing) allAirs[i];
         if (a == null) continue;
-        if (followsTrend(a, true, sbCache))
+        if (followsTrend(a, true, sbCache, false, true))
           rv.add(a);
         if ((i % CPU_CONTROL_MOD_COUNT) == 0 && controlCPUUsage)
           try{Thread.sleep(Carny.SLEEP_PERIOD);}catch(Exception e){}
@@ -566,9 +575,13 @@ public class Agent extends DBObject implements Favorite
 
   public boolean followsTrend(Airing air, boolean mustBeViewable, StringBuffer sbCache)
   {
-    return followsTrend(air, mustBeViewable, sbCache, false);
+    return followsTrend(air, mustBeViewable, sbCache, false, false);
   }
 
+  public boolean followsTrend(Airing air, boolean mustBeViewable, StringBuffer sbCache, boolean skipKeyword)
+  {
+      return followsTrend(air, mustBeViewable, sbCache, skipKeyword, false);
+  }
   /**
    * Determine if the given airing meets the criteria for this Agent. (i.e. could the given Airing be scheduled because
    * of this Agent)
@@ -580,20 +593,22 @@ public class Agent extends DBObject implements Favorite
    * the buffer will be cleared and use.  When calling this method in a loop, the same StringBuffer can be used for each
    * call to limit object creation and memory use.
    * @param skipKeyword If true, keyword matching is not considered
+   * @param ignoreDisabled If true, treat this agent as if it is enabled, even if it isn't.
    * @return true if the given Airing matches this Agent (given the parameter criteria) , false otherwise.
    */
   /*
    * TODO(codefu): skipKeyword is a hack before showcase. It works since the other flags are AND
    * tested; but we can have Lucene do this for us
    */
-  public boolean followsTrend(Airing air, boolean mustBeViewable, StringBuffer sbCache, boolean skipKeyword)
+  public boolean followsTrend(Airing air, boolean mustBeViewable, StringBuffer sbCache, boolean skipKeyword,
+          boolean ignoreDisabled)
   {
     if (air == null) return false;
     Show s = air.getShow();
     if (s == null) return false;
 
     //A disabled agent doesn't match any airings
-    if(testAgentFlag(DISABLED_FLAG))
+    if(!ignoreDisabled && testAgentFlag(DISABLED_FLAG))
         return false;
     // Do not be case sensitive when checking titles!! We got a bunch of complaints about this on our forums.
     // Don't let null titles match all the Favorites!

--- a/java/sage/Version.java
+++ b/java/sage/Version.java
@@ -23,7 +23,7 @@ public class Version
 {
   public static final byte MAJOR_VERSION = 9;
   public static final byte MINOR_VERSION = 0;
-  public static final byte MICRO_VERSION = 14;
+  public static final byte MICRO_VERSION = 15;
 
   public static final String VERSION = MAJOR_VERSION + "." + MINOR_VERSION + "." + MICRO_VERSION + "." + SageConstants.BUILD_VERSION;
 

--- a/java/sage/api/FavoriteAPI.java
+++ b/java/sage/api/FavoriteAPI.java
@@ -1164,7 +1164,10 @@ public class FavoriteAPI {
     rft.put(new PredefinedJEPFunction("Favorite", "GetFavoriteAirings", new String[] { "Favorite" }, true)
     {
       /**
-       * Returns a list of all of the Airings in the database that match this Favorite.
+       * Returns a list of all of the Airings in the database that match this Favorite.  If this Favorite is disabled,
+       * no Airings will be returned.  To get a list of Airings that match a disabled Favorite, call
+       * GetPotentialFavoriteAirings instead.
+       *
        * @param Favorite the Favorite object
        * @return the list of Airings in the DB that match this Favorite
        *
@@ -1175,6 +1178,23 @@ public class FavoriteAPI {
         if (fav == null) return null;
         return fav.getRelatedAirings(Wizard.getInstance().getRawAccess(Wizard.AIRING_CODE,
             Wizard.AIRINGS_BY_CT_CODE), true, false, new StringBuffer());
+      }});
+    rft.put(new PredefinedJEPFunction("Favorite", "GetPotentialFavoriteAirings", new String[] { "Favorite" }, true)
+    {
+      /**
+       * Returns a list of all of the Airings in the database that match this Favorite.  If the favorite is disabled
+       * this API call will ignore that fact and return the Airings that would match this favorite if it were not
+       * disabled.
+       * @param Favorite the Favorite object
+       * @return the list of Airings in the DB that match this Favorite
+       *
+       * @declaration public Airing[] GetPotentialFavoriteAirings(Favorite Favorite);
+       */
+      public Object runSafely(Catbert.FastStack stack) throws Exception{
+        Agent fav = (Agent) stack.pop();
+        if (fav == null) return null;
+        return fav.getRelatedAirings(Wizard.getInstance().getRawAccess(Wizard.AIRING_CODE,
+            Wizard.AIRINGS_BY_CT_CODE), true, false, true, new StringBuffer());
       }});
     rft.put(new PredefinedJEPFunction("Favorite", "GetFavoriteID", new String[] { "Favorite" })
     {

--- a/java/sage/api/FavoriteAPI.java
+++ b/java/sage/api/FavoriteAPI.java
@@ -1189,6 +1189,7 @@ public class FavoriteAPI {
        * @return the list of Airings in the DB that match this Favorite
        *
        * @declaration public Airing[] GetPotentialFavoriteAirings(Favorite Favorite);
+       * @since 9.0.15
        */
       public Object runSafely(Catbert.FastStack stack) throws Exception{
         Agent fav = (Agent) stack.pop();


### PR DESCRIPTION
Creates a new API, GetPotentialFavoriteAirings, that works exactly the same as GetFavoriteAirings, except that it returns the airings as if the airing were enabled, even if the favorite is disabled.

This will be used in an update to the STV to show upcoming airings for a favorite even when it is disabled.  (Issue #154)