### PR TITLE
Disable hwaccels in libMpeg2Transcoder/ffmpeg

### DIFF
--- a/build/buildso.sh
+++ b/build/buildso.sh
@@ -81,7 +81,7 @@ cd ../../third_party/ffmpeg
 make clean
 ./configure --build-suffix=-minimal --disable-static --enable-shared \
   --disable-decoders --disable-encoders --disable-parsers --disable-filters \
-  --disable-protocols --disable-muxers --disable-demuxers --disable-bsfs \
+  --disable-protocols --disable-muxers --disable-demuxers --disable-bsfs --disable-hwaccels \
   --enable-encoder=mpeg1video --enable-encoder=mpeg2video \
   --enable-decoder=mp3 --enable-decoder=mp2 --enable-encoder=mp2 \
   --enable-muxer=mpeg1system --enable-muxer=mpeg1vcd --enable-muxer=mpeg1video \


### PR DESCRIPTION
This fixes a compile time error, caused by hwaccels in ffmpeg being dependant on h264 encoders. Since hwaccels aren't being used, they should be turned off along with all the other unused parts anyway.