### PR TITLE
Fix bash syntax error in startsagecore.

### DIFF
--- a/build/serverfiles/startsagecore
+++ b/build/serverfiles/startsagecore
@@ -33,7 +33,7 @@ fi
 # If we are running Java 8 or 9, enable string deduplication. This has very measurable benefits in
 # multi-miniclient situations.
 JAVA_VERSION=$(java -version 2>&1 | grep -i version | sed 's/.*version ".*\.\(.*\)\..*"/\1/; 1q')
-if [[ "$JAVA_VERSION" == "8" || "$JAVA_VERSION" == "9"]] ; then
+if [[ "$JAVA_VERSION" == "8" || "$JAVA_VERSION" == "9" ]] ; then
     JAVAOPTS="$JAVAOPTS -XX:+UseG1GC -XX:+UseStringDeduplication"
 fi
 


### PR DESCRIPTION
Double end brackets need a space in front.