### PR TITLE
VOB and MP4 subtitles locking methods were not being called.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix: Added support for all 4 tuners on the Hauppauge WinTV-quadHD tuner in Windows.
 * New: Add Schedules Direct lineup by ID.
 * Change: Removed ZZZ from Schedules Direct Regions because it doesn't do anything.
+* Fix: VOB and MP4 subtitles locking methods were not being called.
 
 ## Version 9.1.5 (2017-06-19)
 * Fix: Carny throws a null pointer exception if a show has a null title.

--- a/java/sage/media/sub/MP4TextSubtitleHandler.java
+++ b/java/sage/media/sub/MP4TextSubtitleHandler.java
@@ -58,7 +58,7 @@ public class MP4TextSubtitleHandler extends SubtitleHandler
     String rawText;
     int sizeOffset = 0;
 
-    subtitleLock.readLock();
+    subtitleLock.readLock().lock();
 
     try
     {

--- a/java/sage/media/sub/VobSubSubtitleHandler.java
+++ b/java/sage/media/sub/VobSubSubtitleHandler.java
@@ -279,7 +279,7 @@ public class VobSubSubtitleHandler extends SubtitleHandler
       currMediaTime += delay;
     int rv = 0;
 
-    subtitleLock.writeLock();
+    subtitleLock.writeLock().lock();
 
     try
     {


### PR DESCRIPTION
This fixes issue #333.