### PR TITLE
Schedules Direct person import improvements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 * New: Add Schedules Direct lineup by ID.
 * Change: Removed ZZZ from Schedules Direct Regions because it doesn't do anything.
 * Fix: VOB and MP4 subtitles locking methods were not being called.
+* Fix: Reduced Schedules Direct people image import threads to 4 (including the execution thread) and added logging for when new threads are created for during the process.
+* Change: Removed unhelpful alias to original person log entries.
+* Fix: Fixed issue with Schedules Direct forcing a full airing re-import on stations that do not have a No Data airing.
 
 ## Version 9.1.5 (2017-06-19)
 * Fix: Carny throws a null pointer exception if a show has a null title.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@
 * New: Add Schedules Direct lineup by ID.
 * Change: Removed ZZZ from Schedules Direct Regions because it doesn't do anything.
 * Fix: VOB and MP4 subtitles locking methods were not being called.
-* Fix: Reduced Schedules Direct people image import threads to 4 (including the execution thread) and added logging for when new threads are created for during the process.
+* Fix: Reduced Schedules Direct person image import threads to 4 (including the execution thread) and added logging for when new threads are created for during the process.
 * Change: Removed unhelpful alias to original person log entries.
 * Fix: Fixed issue with Schedules Direct forcing a full airing re-import on stations that do not have a No Data airing.
+* Change: Lowered the priority of the Schedules Direct person image import threads.
 
 ## Version 9.1.5 (2017-06-19)
 * Fix: Carny throws a null pointer exception if a show has a null title.

--- a/java/sage/Person.java
+++ b/java/sage/Person.java
@@ -313,10 +313,12 @@ public class Person extends DBObject
   {
     if (extID >= 0 || orgPerson != null) return;
     orgPerson = Wizard.getInstance().getPersonForExtID(-1 * extID);
-    if (orgPerson == null)
+    // Our primary guide data source Schedules Direct doesn't always have the original person, so
+    // this just creates a lot of annoying log entries.
+    /*if (orgPerson == null)
     {
       if (Sage.DBG) System.out.println("ERROR Could not resolve aliased person back to original person id=" + (-1*extID) + " name=" + name);
-    }
+    }*/
   }
 
   /**

--- a/java/sage/epg/sd/SDRipper.java
+++ b/java/sage/epg/sd/SDRipper.java
@@ -2233,6 +2233,10 @@ public class SDRipper extends EPGDataSource
                   if (Sage.DBG) System.out.println("SDEPG Starting new import thread...");
                   Thread returnThread = new Thread(r);
                   returnThread.setName("SDEPG-Import");
+                  // I don't believe this has created any issues, but let's not allow these threads
+                  // to run at the same priority as threads that directly impact the UI experience
+                  // just in case.
+                  returnThread.setPriority(Thread.MIN_PRIORITY + 1);
                   return returnThread;
                 }
               };


### PR DESCRIPTION
I reduced the thread count to 4 for importing person images because computers with slower connections don't appear to be able to keep up with 16 simultaneous connections which appears to have lead to threads terminating early in the thread executor (the queue is empty and 5 seconds have passed), leading to excessive thread creation.

I added additional logging in the key areas that would provide us with some insight if this kind of situation is still a problem for the affected users after upgrading.