### PR TITLE
Added more exception handling and made the thread executor always start 3 threads and keep them running.

### DIFF
--- a/java/sage/epg/sd/SDRipper.java
+++ b/java/sage/epg/sd/SDRipper.java
@@ -75,8 +75,6 @@ import java.util.StringTokenizer;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -2221,7 +2219,10 @@ public class SDRipper extends EPGDataSource
           int remainingImports;
           final AtomicInteger totalPeople = new AtomicInteger(0);
           BlockingQueue<Runnable> queue = new ArrayBlockingQueue<>(9);
-          ThreadPoolExecutor executor = new ThreadPoolExecutor(1, 3, 60000, TimeUnit.MILLISECONDS, queue) {
+          // We are using a fixed thread size so they don't get re-created ever. This was a big
+          // problem for users with slow internet connections because a full minute would actually
+          // timeout while this thread was executing, then a new thread would need to spin up.
+          ThreadPoolExecutor executor = new ThreadPoolExecutor(3, 3, 0L, TimeUnit.MILLISECONDS, queue) {
             @Override
             public ThreadFactory getThreadFactory()
             {
@@ -2256,60 +2257,68 @@ public class SDRipper extends EPGDataSource
               @Override
               public void run()
               {
-                String personName = person.getName();
-                int personId = person.getPersonIdAsInt();
-                int nameId = person.getNameIdAsInt();
-                String lookupPersonId = person.getPersonId();
-
-                // If these don't match, this is an alias.
-                if (personId != 0 && personId == nameId)
-                  personId *= -1;
-
-                // We don't have any sources for these at the moment. It might not be a bad idea to see
-                // if we can hook into well-established free sources reliably for this extra data
-                // (e.g. TheTVDB.com).
-                int personDob = 0;
-                int personDod = 0;
-                String birthPlace = "";
-                short yearList[] = Pooler.EMPTY_SHORT_ARRAY;
-                String awardList[] = Pooler.EMPTY_STRING_ARRAY;
-
-                byte headShotUrls[][];
-                if (lookupPersonId.length() > 0)
+                try
                 {
-                  try
+                  String personName = person.getName();
+                  int personId = person.getPersonIdAsInt();
+                  int nameId = person.getNameIdAsInt();
+                  String lookupPersonId = person.getPersonId();
+
+                  // If these don't match, this is an alias.
+                  if (personId != 0 && personId == nameId)
+                    personId *= -1;
+
+                  // We don't have any sources for these at the moment. It might not be a bad idea
+                  // to see if we can hook into well-established free sources reliably for this
+                  // extra data (e.g. TheTVDB.com).
+                  int personDob = 0;
+                  int personDod = 0;
+                  String birthPlace = "";
+                  short yearList[] = Pooler.EMPTY_SHORT_ARRAY;
+                  String awardList[] = Pooler.EMPTY_STRING_ARRAY;
+
+                  byte headShotUrls[][];
+                  if (lookupPersonId.length() > 0)
                   {
-                    headShotUrls = SDImages.encodeHeadShots(ensureSession().getCelebrityImages(lookupPersonId));
-                  }
-                  catch (Exception e)
-                  {
-                    // Issues in getting head-shots should not be considered a significant
-                    // issue, but we will report it in case it becomes the source of a major
-                    // issue.
-                    SDSageSession.writeDebugException(e);
-                    if (Sage.DBG)
+                    try
                     {
-                      System.out.println("SDEPG Unable to get head-shots for: " + person);
-                      e.printStackTrace(System.out);
+                      headShotUrls = SDImages.encodeHeadShots(ensureSession().getCelebrityImages(lookupPersonId));
                     }
+                    catch (Throwable e)
+                    {
+                      // Issues in getting head-shots should not be considered a significant issue,
+                      // but we will report it in case it becomes the source of a major issue.
+                      SDSageSession.writeDebugException(e);
+                      if (Sage.DBG)
+                      {
+                        System.out.println("SDEPG Unable to get head-shots for: " + person);
+                        e.printStackTrace(System.out);
+                      }
+                      headShotUrls = Pooler.EMPTY_2D_BYTE_ARRAY;
+                    }
+                  }
+                  else
+                  {
                     headShotUrls = Pooler.EMPTY_2D_BYTE_ARRAY;
                   }
+
+                  // Since no other details would be updated, we can just skip this update
+                  // completely. This should be removed or expanded if more data becomes available
+                  // in the future.
+                  if (headShotUrls.length == 0)
+                    return;
+
+                  totalPeople.incrementAndGet();
+
+                  //System.out.println("SDEPG added head-shots for: " + person);
+                  threadWiz.addPerson(personName, personId, personDob, personDod, birthPlace,
+                    yearList, awardList, headShotUrls, DBObject.MEDIA_MASK_TV);
                 }
-                else
+                catch (Throwable e)
                 {
-                  headShotUrls = Pooler.EMPTY_2D_BYTE_ARRAY;
+                  System.out.println("SDEPG Unexpected exception getting head-shots for: " + person);
+                  e.printStackTrace(System.out);
                 }
-
-                // Since no other details would be updated, we can just skip this update completely.
-                // This should be removed or expanded if more data becomes available in the future.
-                if (headShotUrls.length == 0)
-                  return;
-
-                totalPeople.incrementAndGet();
-
-                //System.out.println("SDEPG added head-shots for: " + person);
-                threadWiz.addPerson(personName, personId, personDob, personDod, birthPlace,
-                  yearList, awardList, headShotUrls, DBObject.MEDIA_MASK_TV);
               }
             };
 
@@ -2317,7 +2326,10 @@ public class SDRipper extends EPGDataSource
           }
 
           executor.shutdown();
-          executor.awaitTermination(60000, TimeUnit.MILLISECONDS);
+          // Some people have extremely slow internet connections that actually warrant this lengthy
+          // wait. This will return the instant the queue is empty, so it's not like everyone will
+          // be waiting for 5 minutes to pass.
+          executor.awaitTermination(5, TimeUnit.MINUTES);
           // It's not a problem to not wait for the potentially remaining threads to complete. The
           // operation is thread-safe.
           addedAliases.clear();


### PR DESCRIPTION
It turns out we have some users with even slower internet access than I ever expected and the threads are still idling long enough they stop and later get restarted. Now we just start all of the needed threads and leave them running until the executor is shutdown and the queue is empty.