### PR TITLE
Fix: Added support for 2nd tuner of Hauppauge WinTV-dualHD usb stick (Windows)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Version 9.1.7 (2017-08-10)
+* Fix: add support for 2nd tuner of Hauppauge WinTV-dualHD usb tuner stick.
+* Fix: add support for 3rd & 4th tuners of Hauppauge WinTV-quadHD PCIe tuner card (2017-06-27).
+
 ## Version 9.1.6 (2017-08-10)
 * Fix: Various fixes and cleanup on Linux Firewire and DVB.
 * Fix: Added support for all 4 tuners on the Hauppauge WinTV-quadHD tuner in Windows.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 # Change Log
 
-## Version 9.1.7 (2017-08-10)
-* Fix: add support for 2nd tuner of Hauppauge WinTV-dualHD usb tuner stick.
-* Fix: add support for 3rd & 4th tuners of Hauppauge WinTV-quadHD PCIe tuner card (2017-06-27).
+* Fix: add support for 2nd tuner of Hauppauge WinTV-dualHD usb tuner stick (Windows).
 
 ## Version 9.1.6 (2017-08-10)
 * Fix: Various fixes and cleanup on Linux Firewire and DVB.

--- a/native/dll/DShowCapture-2/DShowUtilities.cpp
+++ b/native/dll/DShowCapture-2/DShowUtilities.cpp
@@ -119,15 +119,15 @@ HRESULT GetDeviceInfo( char*  pCaptureDevName, DEVICE_DRV_INF* pDrvInfo )
 
 	if ( strstr ( pCaptureDevName, "fd0a5af4-b41d-11d2-9c95-00c04f7971e0" ) != NULL )
 	{
-		pDrvInfo->device_class = 3;
+		pDrvInfo->device_class = 3; // BDA Receiver components (TS Capture)
 	} else
 	if ( strstr ( pCaptureDevName, "71985f48-1ca1-11d3-9cc8-00c04f7971e0" ) != NULL )
 	{
-		pDrvInfo->device_class = 2;
+		pDrvInfo->device_class = 2; // BDA Source Filters (Tuners)
 	} else
 	if ( strstr ( pCaptureDevName, "71985f4b-1ca1-11d3-9cc8-00c04f7971e0" ) != NULL )
 	{
-		pDrvInfo->device_class = 1;
+		pDrvInfo->device_class = 1; // BDA Network Providers
 	} 
 
 	if ( p = strstr( pCaptureDevName, "@device:sw:" ) ) //software device

--- a/native/dll/DShowCapture-2/DeviceDiscovery.cpp
+++ b/native/dll/DShowCapture-2/DeviceDiscovery.cpp
@@ -492,7 +492,7 @@ static int MergeNameList( JNIEnv *env, DEVNAME* DevName, int numDev, DEVNAME* De
                     slog((env, "patch: replace old DevName[%d] '%s' with new DevName1[%d] '%s' \r\n", 
                         j, DevName[j].FriendlyName, i, DevName1[i].FriendlyName));
 
-                    strncpy(DevName[j].FriendlyName, DevName1[i].FriendlyName, sizeof(DevName1[i].FriendlyName) - 1);
+                    strncpy(DevName[j].FriendlyName, DevName1[i].FriendlyName, sizeof(DevName[j].FriendlyName) - 1);
                 }
 
                 // Add 2nd Tuner, either 'Hauppauge WinTV-dualHD ATSC Tuner' or 'Hauppauge WinTV-dualHD ATSC Tuner 2'

--- a/native/dll/DShowCapture-2/DeviceVerify.cpp
+++ b/native/dll/DShowCapture-2/DeviceVerify.cpp
@@ -130,6 +130,15 @@ JNIEXPORT jint JNICALL Java_sage_DShowCaptureDevice_isCaptureDeviceValid0
 	}
 	//processing passed in configure name with tag<...>
 
+    // KSF: 
+    // Users that had plugged in this device prior to dual-tuner support will have a TS Capture entry in sage.properties.
+    // We don't want them to see that any more in the Setup Video Sources UI.  
+    // With this hack, they'll only see the 2 new 'Hauppauge WinTV-dualHD ATSC Tuner' entries.
+    if (!strncmp(capFiltName, "Hauppauge WinTV-dualHD TS Capture", sizeof("Hauppauge WinTV-dualHD TS Capture"))) 
+    {
+        slog((env, "hardcode: ignoring legacy device '%s' because WinTV-dualHD Tuner(s) are now supported \r\n", capFiltName));
+        return sage_DShowCaptureDevice_DEVICE_NO_EXIST;
+    }
 
 //	CoInitializeEx(NULL, COM_THREADING_MODE);
 	IBaseFilter* pFilter = NULL;
@@ -183,7 +192,7 @@ JNIEXPORT jint JNICALL Java_sage_DShowCaptureDevice_isCaptureDeviceValid0
 
 		SAFE_RELEASE(pFilter);
 	}
-
+ 
 	if (FAILED(hr))
 	{
 		if ( !strncmp( capFiltName, "PUSH TS SOURCE", 14 ) ) //hard code "PUSH TS SOURCE"  for debug dump data
@@ -1052,7 +1061,7 @@ BOOL CheckFakeBDACrossBar( JNIEnv *env, char* capFiltName, int CapFiltNum, char*
 	CLSID CapClassidCategory;
     DEVICE_DRV_INF  BDACaptureDrvInfo;
 	DEVICE_DRV_INF  VideoCaptureDrvInfo;
-    // slog((env, "CheckFakeBDACrossBar Entry: capFiltName %s, CapFiltNum %d, BDAFiltDevName %s \r\n", capFiltName, CapFiltNum, BDAFiltDevName)); 
+    // slog((env, "CheckFakeBDACrossBar Entry: capFiltName %s, CapFiltNum %d \r\n", capFiltName, CapFiltNum));
     try
 	{
 		IBaseFilter* pFilter = NULL;


### PR DESCRIPTION
The Hauppauge WinTV-dualHD usb stick is a dual-tuner device.  Hauppauge's BDA driver registers only a single Receiver Component ('TS Capture') for it's 2 Source Filters (ATSC Tuner, ATSC Tuner 2).  Historically, this caused Sage to present only a single Video Capture device to the user ('Hauppauge WinTV-dualHD TS Capture').

This fix makes both tuners usable under Windows.

As a side effect, any user who had previously used & configured the dualHD device (as '...TS Capture') will need to Add and configure the 2 tuners ('...ATSC Tuner' and '...ATSC Tuner 2').  This is necessary because of the way Hauppauge's BDA driver presents the internal devices.

The fix has also been verified by Forum user (and Moderator) SHS.
