### PR TITLE
HD-PVR2 & HD PVR 60 capture device support (Windows)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+* HD-PVR2 video capture device: add ability to select multiple audio inputs (Windows)
+* HD PVR 60 video capture device: new device support (Windows)
+
 ## Version 9.1.7 (2017-09-24)
 * Fix: add support for 2nd tuner of Hauppauge WinTV-dualHD usb tuner stick (Windows).
 * Changes in the STV set 2017081201 for the next SageTV release v9.1.7.0:

--- a/installer/wix/SageTVSetup/sagetvregistry.wxs
+++ b/installer/wix/SageTVSetup/sagetvregistry.wxs
@@ -292,6 +292,13 @@
                     <RegistryValue Name="CaptureMask" Value="2048" Type="integer" />
                     <RegistryValue Name="ChipsetMask" Value="1048576" Type="integer" />
                 </RegistryKey>
+	</Component>
+            <Component Id="cmpRegFreyCommonAddCaptureHDPVR60CaptureFilterHD" Guid="{B8FE962B-AA0A-495C-91D5-3043CE986AEC}" KeyPath="yes">
+                <RegistryKey ForceCreateOnInstall="yes" Key="SOFTWARE\Frey Technologies\Common\AdditionalCaptureSetups\HD PVR 60 Capture Filter (HD)" Root="HKLM">
+	            <Permission GenericAll="yes" User="Everyone"/>
+                    <RegistryValue Name="CaptureMask" Value="2048" Type="integer" />
+                    <RegistryValue Name="ChipsetMask" Value="1048576" Type="integer" />
+                </RegistryKey>
             </Component>
             <Component Id="cmpRegFreyCommonDSFilters" Guid="{6E0BEF6D-3033-46DF-A5E1-9C92C72793B0}" KeyPath="yes">
               <RegistryKey ForceCreateOnInstall="yes" Key="SOFTWARE\Frey Technologies\Common\DSFilters" Root="HKLM">
@@ -364,6 +371,7 @@
             <ComponentRef Id="cmpRegFreyCommonAddCaptureViXSPureTVCapture" />
             <ComponentRef Id="cmpRegFreyCommonAddCaptureXtremeTVPCITVTuner" />
             <ComponentRef Id="cmpRegFreyCommonAddCaptureHauppaugeSienaVideoCapture" />
+            <ComponentRef Id="cmpRegFreyCommonAddCaptureHDPVR60CaptureFilterHD" />
             <ComponentRef Id="cmpRegFreyCommonDSFilters" />
             <ComponentRef Id="cmpRegFreyCommonDSFiltersMpegDeMux" />
             <ComponentRef Id="cmpRegFreyCommonDSFiltersMpegMux" />

--- a/java/sage/CaptureDeviceInput.java
+++ b/java/sage/CaptureDeviceInput.java
@@ -39,6 +39,9 @@ public class CaptureDeviceInput
   public static final String TUNING_PLUGIN_PORT = "tuning_plugin_port";
   private static final String SFIR_DEV_NAME = "sfir_dev_name";
   private static final String IR_XMT_PORT = "ir_xmt_port";
+  public static final int HDMI_LINEIN_CROSSBAR_INDEX = 80;
+  public static final int HDMI_AES_CROSSBAR_INDEX = 81; // HDMI Video & Audio
+  public static final int HDMI_SPDIF_CROSSBAR_INDEX = 82;
   public static final int YPBPR_SPDIF_CROSSBAR_INDEX = 90;
   public static final int FM_RADIO_CROSSBAR_INDEX = 99;
   public static final int DIGITAL_TUNER_CROSSBAR_INDEX = 100;
@@ -61,7 +64,7 @@ public class CaptureDeviceInput
     else if (x == 6)
       return "HDMI"; // DShow says 'SerialDigital', but I've only ever seen this with the Hauppauge HD PVR PCIe card and on that it's HDMI
     else if (x == 7)
-      return "ParallelDigital";
+      return Sage.rez("Digital"); // Dshow 'PhysConn_Video_ParallelDigital'
     else if (x == 8)
       return "SCSI";
     else if (x == 9)
@@ -84,6 +87,12 @@ public class CaptureDeviceInput
       return Sage.rez("Digital_TV_Tuner");
     else if (x == YPBPR_SPDIF_CROSSBAR_INDEX)
       return Sage.rez("Component") + "+SPDIF";
+    else if (x == HDMI_LINEIN_CROSSBAR_INDEX)
+      return Sage.rez("HDMI") + "+LineIn";
+    else if (x == HDMI_AES_CROSSBAR_INDEX)
+      return Sage.rez("HDMI") + "_AV";
+    else if (x == HDMI_SPDIF_CROSSBAR_INDEX)
+      return Sage.rez("HDMI") + "+SPDIF";
     else
       return Sage.rez("Unknown");
   }

--- a/native/include/sage_DShowCaptureDevice.h
+++ b/native/include/sage_DShowCaptureDevice.h
@@ -71,6 +71,7 @@ extern "C" {
 #define sage_DShowCaptureDevice_BDA_RECEIVER_COMPONENT_MASK 262144L // 0x40000
 #undef sage_DShowCaptureDevice_BDA_VIRTUAL_TUNER_MASK
 #define sage_DShowCaptureDevice_BDA_VIRTUAL_TUNER_MASK 524288L  // 0x80000
+    // NOTE: 0x0200000L - 0x1000000L defined & used in Java code
 #undef sage_DShowCaptureDevice_FM_RADIO_FREQ_MAX
 #define sage_DShowCaptureDevice_FM_RADIO_FREQ_MAX 108100000L
 #undef sage_DShowCaptureDevice_FM_RADIO_FREQ_MIN


### PR DESCRIPTION
* HD-PVR2 video capture device: add ability to select multiple audio inputs (Windows)
* HD PVR 60 video capture device: new device support (Windows)

Beta tested by Sage forum user (& moderator) SHS
Regression tested with Hauppauge capture devices: HD-PVR, HD-PRV2, Colossus
