### PR TITLE
Fix wiz.bin DB crashes when a description is longer than 32KB

### DIFF
--- a/java/sage/Show.java
+++ b/java/sage/Show.java
@@ -675,7 +675,7 @@ public final class Show extends DBObject
       out.writeShort(barr.length);
       out.write(barr);
     } else {
-        out.writeUTF(descStr);
+      out.writeUTF(descStr);
     }
 
     out.writeInt((categories.length == 0) ? 0 : (useLookupIdx ? categories[0].lookupIdx : categories[0].id));
@@ -690,44 +690,57 @@ public final class Show extends DBObject
 
     out.writeInt((rated == null) ? 0 : (useLookupIdx ? rated.lookupIdx : rated.id));
     out.writeInt(ers.length);
-    for (int i = 0; i < ers.length; i++)
+    for (int i = 0; i < ers.length; i++) {
       out.writeInt(useLookupIdx ? ers[i].lookupIdx : ers[i].id);
+    }
 
     out.writeInt((year == null) ? 0 : (useLookupIdx ? year.lookupIdx : year.id));
     out.writeInt((pr == null) ? 0 : (useLookupIdx ? pr.lookupIdx : pr.id));
 
     out.writeInt(bonuses.length);
-    for (int i = 0; i < bonuses.length; i++)
+    for (int i = 0; i < bonuses.length; i++) {
       out.writeInt(useLookupIdx ? bonuses[i].lookupIdx : bonuses[i].id);
+    }
 
     long lastWatchedData = lastWatched;
     if (dontLike) {
-      if (lastWatchedData == 0)
+      if (lastWatchedData == 0) {
         lastWatchedData = -1;
-      else
+      } else {
         lastWatchedData *= -1;
+      }
     }
     out.writeLong(lastWatchedData);
     out.writeBoolean(/*forcedFirstRun*/false); // old first run data
     out.writeShort(externalID.length);
-    if (externalID.length > 0)
+
+    if (externalID.length > 0) {
       out.write(externalID);
+    }
+
     out.writeInt(/*updateCount*/id);
     out.writeInt((language == null) ? 0 : (useLookupIdx ? language.lookupIdx : language.id));
     out.writeLong(originalAirDate);
     out.writeShort(seasonNum);
     out.writeShort(episodeNum);
     out.writeShort(Math.max(0, categories.length - 2));
-    for (int i = 2; i < categories.length; i++)
+
+    for (int i = 2; i < categories.length; i++) {
       out.writeInt(useLookupIdx ? categories[i].lookupIdx : categories[i].id);
+    }
+
     out.writeBoolean(cachedUnique == FORCED_UNIQUE);
     out.writeShort(altEpisodeNum);
     out.writeInt(showcardID);
     out.writeInt(seriesID);
     out.writeShort(imageIDs.length);
-    for (int i = 0; i < imageIDs.length; i++)
+
+    for (int i = 0; i < imageIDs.length; i++) {
       out.writeShort(imageIDs[i]);
+    }
+
     out.writeShort(imageURLs.length);
+
     for (int i = 0; i < imageURLs.length; i++)
     {
       out.writeShort(imageURLs[i].length);

--- a/java/sage/Show.java
+++ b/java/sage/Show.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.lang.Short;
 
 public final class Show extends DBObject
 {
@@ -656,7 +657,20 @@ public final class Show extends DBObject
     }
     else
       out.writeUTF(episodeNameStr);
+
     barr = descBytes;
+
+    /*
+     * if the description is bigger than the max
+     * short value then nullify barr forcing into
+     * the else block below using the string rather
+     * than the byte array
+    */
+
+    if (barr != null && barr.length > Short.MAX_VALUE) {
+        barr = null;
+    }
+
     if (barr != null) {
       out.writeShort(barr.length);
       out.write(barr);
@@ -1578,3 +1592,5 @@ public final class Show extends DBObject
     }
   };
 }
+  }
+  };

--- a/java/sage/Show.java
+++ b/java/sage/Show.java
@@ -654,9 +654,9 @@ public final class Show extends DBObject
     if (barr != null) {
       out.writeShort(barr.length);
       out.write(barr);
-    }
-    else
+    } else {
       out.writeUTF(episodeNameStr);
+    }
 
     barr = descBytes;
 
@@ -674,9 +674,10 @@ public final class Show extends DBObject
     if (barr != null) {
       out.writeShort(barr.length);
       out.write(barr);
+    } else {
+        out.writeUTF(descStr);
     }
-    else
-      out.writeUTF(descStr);
+
     out.writeInt((categories.length == 0) ? 0 : (useLookupIdx ? categories[0].lookupIdx : categories[0].id));
     out.writeInt((categories.length < 2) ? 0 : (useLookupIdx ? categories[1].lookupIdx : categories[1].id));
 

--- a/java/sage/Show.java
+++ b/java/sage/Show.java
@@ -320,32 +320,35 @@ public final class Show extends DBObject
   void update(DBObject x)
   {
     Show fromMe = (Show) x;
-    duration = fromMe.duration;
-    lastWatched = fromMe.lastWatched;
-    dontLike = fromMe.dontLike;
-    title = fromMe.title;
-    episodeNameStr = fromMe.episodeNameStr;
-    externalID = fromMe.externalID;
-    descStr = fromMe.descStr;
-    categories = fromMe.categories;
-    people = fromMe.people;
-    roles = fromMe.roles;
-    rated = fromMe.rated;
-    ers = fromMe.ers;
-    year = fromMe.year;
-    pr = fromMe.pr;
-    bonuses = fromMe.bonuses;
-    language = fromMe.language;
-    originalAirDate = fromMe.originalAirDate;
-    seasonNum = fromMe.seasonNum;
-    episodeNum = fromMe.episodeNum;
+
+    duration            = fromMe.duration;
+    lastWatched         = fromMe.lastWatched;
+    dontLike            = fromMe.dontLike;
+    title               = fromMe.title;
+    episodeNameStr      = fromMe.episodeNameStr;
+    externalID          = fromMe.externalID;
+    descStr             = fromMe.descStr;
+    categories          = fromMe.categories;
+    people              = fromMe.people;
+    roles               = fromMe.roles;
+    rated               = fromMe.rated;
+    ers                 = fromMe.ers;
+    year                = fromMe.year;
+    pr                  = fromMe.pr;
+    bonuses             = fromMe.bonuses;
+    language            = fromMe.language;
+    originalAirDate     = fromMe.originalAirDate;
+    seasonNum           = fromMe.seasonNum;
+    episodeNum          = fromMe.episodeNum;
+
     if (fromMe.cachedUnique == FORCED_UNIQUE)
       cachedUnique = FORCED_UNIQUE;
-    altEpisodeNum = fromMe.altEpisodeNum;
-    seriesID = fromMe.seriesID;
-    showcardID = fromMe.showcardID;
-    imageIDs = fromMe.imageIDs;
-    imageURLs = fromMe.imageURLs;
+
+    altEpisodeNum   = fromMe.altEpisodeNum;
+    seriesID        = fromMe.seriesID;
+    showcardID      = fromMe.showcardID;
+    imageIDs        = fromMe.imageIDs;
+    imageURLs       = fromMe.imageURLs;
     super.update(fromMe);
   }
   @Override
@@ -423,6 +426,9 @@ public final class Show extends DBObject
   Show(DataInput in, byte ver, Map<Integer, Integer> idMap) throws IOException
   {
     super(in, ver, idMap);
+
+    int size        = 0;
+
     Wizard wiz      = Wizard.getInstance();
     duration        = in.readLong();
     title           = wiz.getTitleForID(readID(in, idMap));
@@ -1496,7 +1502,9 @@ public final class Show extends DBObject
   long duration;
   Stringer title;
   volatile String episodeNameStr;
+  byte[] episodeNameBytes; /* deprecated no longer used */
   volatile String descStr;
+  byte[] descBytes; /* deprecated no longer used */
   Stringer[] categories;
   Person[] people;
   byte[] roles;

--- a/java/sage/Show.java
+++ b/java/sage/Show.java
@@ -1606,5 +1606,3 @@ public final class Show extends DBObject
     }
   };
 }
-  }
-  };


### PR DESCRIPTION
Don't write to Show desc data via bytes when the length is greater than 32KB, instead opting to use the desc string.  I am creating the PR to create the discussion. . .I'm pretty sure there should be something done on the read side as well around line 477, b/c it's calling readShort to get the size and I'm not sure that's good either, but not sure how to fix that. . . 

