### PR TITLE
Fix long desc / episode name crash 

### DIFF
--- a/java/sage/Wizard.java
+++ b/java/sage/Wizard.java
@@ -4541,9 +4541,7 @@ public class Wizard implements EPGDBPublic2
       s.duration = duration;
       s.title = getTitleForName(title, mediaMask);
       s.episodeNameStr = (episodeName == null) ? "" : new String(episodeName);
-      s.episodeNameBytes = null;
       s.descStr = (desc == null) ? "" : new String(desc);
-      s.descBytes = null;
       if (!fromAPlugin && extID.startsWith("MV") && (categories == null || categories.length == 0 || !Sage.rez("Movie").equals(categories[0])))
       {
         if (categories == null)


### PR DESCRIPTION
When a show desc or episdode name is longer than 32KB the import will fail due to reading old byte arrays and their lengths as shorts.  Remove the byte arrays in favor of just using strings so the application doesn't crash.

