### PR TITLE
Block NULL people/characters in addSeriesInfo.

### DIFF
--- a/java/sage/Wizard.java
+++ b/java/sage/Wizard.java
@@ -3088,21 +3088,35 @@ public class Wizard implements EPGDBPublic2
       series.airDow = (airDOW == null) ? "" : new String(airDOW);
       series.airHrMin = (airHrMin == null) ? "" : new String(airHrMin);
       series.imageUrl = (imageUrl == null) ? "" : new String(imageUrl);
-      if (people == null || people.length == 0)
+      int sz = 0;
+      if (people != null && characters != null)
+      {
+        if (people.length != characters.length)
+          throw new InternalError("ERROR length of people & character arrays do not match!");
+
+        for (int i = 0; i < people.length; i++)
+        {
+          if ((people[i] != null) && (characters[i] != null)) sz++;
+        }
+      }
+      if (people == null || characters == null || sz == 0)
       {
         series.people = Pooler.EMPTY_PERSON_ARRAY;
         series.characters = Pooler.EMPTY_STRING_ARRAY;
       }
       else
       {
-        series.people = new Person[people.length];
-        series.characters = new String[characters.length];
-        if (people.length != characters.length)
-          throw new InternalError("ERROR length of people & character arrays do not match!");
-        for (int i = 0; i < people.length; i++)
+        series.people = new Person[sz];
+        series.characters = new String[sz];
+        for (int i = 0, j = 0; i < people.length; i++)
         {
-          series.people[i] = people[i];
-          series.characters[i] = new String(characters[i]);
+          if ((people[i] != null) && (characters[i] != null))
+          {
+            series.people[j] = people[i];
+            series.characters[j] = new String(characters[i]);
+            j++;
+          }
+          else if (Sage.DBG) System.out.println("addSeriesInfo: Attempting to add null person or character!  Series=" + series.getTitle() + ", person #" + i);
         }
       }
       if (seriesImages == null || seriesImages.length == 0)


### PR DESCRIPTION
This addresses issue #383 where NULL people were added to SeriesInfo, which in turn caused exceptions when accessed later.  User graywolf has been running a jar with this modified code for the past 3 weeks with good results, including a debug log event showing a caught NULL.  I recompiled and tested the jar fresh from this PR commit this evening.

I left the debug log statement in there because it should be rare and can help identify the source of these NULLs.  In this case, I believe BMT may be providing the seriesinfo data.