### PR TITLE
Add support for HVR-4400 and other 885 variants (Windows)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -995,3 +995,9 @@ third_party/ffmpeg/vhook/
 third_party/mplayer/liba52/liba52.a
 third_party/ffmpeg/libavformat/thp.d
 
+native/.vs/SageWorkspace/v14/.suo
+
+
+*.log
+native/SageWorkspace.VC.db
+native/SageWorkspace.VC.VC.opendb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change Log
 
+* Fix: Add support for HVR-4400 and other 885 variants (Windows) 
+
 ## Version 9.1.10 (2018-10-13)
 * removed old bytes properties for episodeName and desc to resolve potential crashes
 

--- a/native/dll/DShowCapture-2/CAMCtrl.cpp
+++ b/native/dll/DShowCapture-2/CAMCtrl.cpp
@@ -238,7 +238,7 @@ int OpenCAM( JNIEnv *env, DShowCaptureInfo* pCapInfo )
 		ret = OpenTechnoTrendCI( env, pCapInfo );
 	} else
 	{
-		slog(( "CAM:unkown CAM/CI device %s %s-%d\r\n", pTag,
+		slog(( "CAM:unknown CAM/CI device %s %s-%d\r\n", pTag,
 			            pCapInfo->videoCaptureFilterName, pCapInfo->videoCaptureFilterNum ));
 		ret = -1;
 	}
@@ -273,7 +273,7 @@ int CloseCAM( JNIEnv *env, DShowCaptureInfo* pCapInfo )
 		ret = CloseTechnoTrendCI( env, pCapInfo );
 	} else
 	{
-		slog(( "CAM:unkown device %s %s-%d\r\n", pTag,
+		slog(( "CAM:unknown device %s %s-%d\r\n", pTag,
 			            pCapInfo->videoCaptureFilterName, pCapInfo->videoCaptureFilterNum ));
 		ret = -1;
 	}
@@ -306,7 +306,7 @@ void EnableCAMPMT( JNIEnv *env, DShowCaptureInfo* pCapInfo )
 		((CAM_CTRL_HEADER*)pCapInfo->pCamCtrlData)->OnPMTEnable = true;
 	} else
 	{
-		slog(( "CAM:unkown device %s %s-%d\r\n", pTag,
+		slog(( "CAM:unknown device %s %s-%d\r\n", pTag,
 			            pCapInfo->videoCaptureFilterName, pCapInfo->videoCaptureFilterNum ));
 	}
 }
@@ -334,7 +334,7 @@ void DisableCAMPMT( JNIEnv *env, DShowCaptureInfo* pCapInfo )
 		((CAM_CTRL_HEADER*)pCapInfo->pCamCtrlData)->OnPMTEnable = false;
 	} else
 	{
-		slog(( "CAM:unkown device %s %s-%d\r\n", pTag,
+		slog(( "CAM:unknown device %s %s-%d\r\n", pTag,
 			            pCapInfo->videoCaptureFilterName, pCapInfo->videoCaptureFilterNum ));
 	}
 }
@@ -368,7 +368,7 @@ int  SwitchCamChannel( JNIEnv *env, DShowCaptureInfo* pCapInfo, int serviceId, i
 		ret = TechnoTrendCamSwitchChannel( env, pCapInfo, serviceId );
 	} else
 	{
-		slog(( "CAM:unkown device %s %s-%d\r\n", pTag,
+		slog(( "CAM:unknown device %s %s-%d\r\n", pTag,
 			            pCapInfo->videoCaptureFilterName, pCapInfo->videoCaptureFilterNum ));
 		ret = -1;
 	}
@@ -429,7 +429,7 @@ long OnCamPMT( void* context, short bytes, void* mesg )
 	} else
 	{
 		return 0;
-		 slog(( "CAM: Unknown card type for OnCamPTM: unkown name %s-%d\r\n", 
+		 slog(( "CAM: Unknown card type for OnCamPTM: unknown name %s-%d\r\n", 
 														   pCapInfo->videoCaptureFilterName, 
 			                                               pCapInfo->videoCaptureFilterNum ));
 	}
@@ -1534,7 +1534,7 @@ static int GetTechnoTrendDeviceType( JNIEnv *env, DShowCaptureInfo* pCapInfo )
       {
         // _log.Info("Technotrend Unknown card type");
          deviceType = TypeUnknown;
-		 slog(( "CAM:TechnoTrend card type: unkown name %s-%d\r\n", pCapInfo->videoCaptureFilterName, 
+		 slog(( "CAM:TechnoTrend card type: unknown name %s-%d\r\n", pCapInfo->videoCaptureFilterName, 
 			                                               pCapInfo->videoCaptureFilterNum ));
       }
 
@@ -1567,7 +1567,7 @@ static int OpenTechnoTrendCI( JNIEnv *env, DShowCaptureInfo* pCapInfo )
 
 	if ( pTechnoTrend->deviceType == TypeUnknown )
 	{
-		slog(( "CAM:Failed open TechnoTrend device, due to unkown device type %s-%d\r\n", 
+		slog(( "CAM:Failed open TechnoTrend device, due to unknown device type %s-%d\r\n", 
 			 pCapInfo->videoCaptureFilterName, pCapInfo->videoCaptureFilterNum ));
 		return -1;
 	}

--- a/native/dll/DShowCapture-2/Crossbar.cpp
+++ b/native/dll/DShowCapture-2/Crossbar.cpp
@@ -38,7 +38,7 @@ void BDAGraphConnectDumpSink( JNIEnv* env, DShowCaptureInfo *pCapInfo, IGraphBui
 void BDAGraphDisconnectDumpSink( JNIEnv* env, DShowCaptureInfo *pCapInfo, IGraphBuilder* pGraph );
 void ClearUpDebugFileSource( JNIEnv* env, DShowCaptureInfo *pCapInfo, IGraphBuilder* pGraph );
 HRESULT TurnBDAChannel( JNIEnv *env, DShowCaptureInfo* pCapInfo, const char* cnum  );
-HRESULT ChannelSinalStrength( JNIEnv *env, DShowCaptureInfo* pCapInfo, long *strength, long* quality, bool* locked );
+HRESULT ChannelSignalStrength( JNIEnv *env, DShowCaptureInfo* pCapInfo, long *strength, long* quality, bool* locked );
 void BDAGraphConnectDebugRawDumpSink( JNIEnv* env, DShowCaptureInfo *pCapInfo, IGraphBuilder* pGraph  );
 void BDAGraphSetDebugRawDumpFileName( JNIEnv* env, DShowCaptureInfo *pCapInfo, IGraphBuilder* pGraph, char* Channel  );
 void BDAGraphSetDebugFileSource( JNIEnv* env, DShowCaptureInfo *pCapInfo, IGraphBuilder* pGraph  );
@@ -697,7 +697,7 @@ JNIEXPORT jint JNICALL Java_sage_DShowCaptureDevice_getSignalStrength0
 			return 100;
 
 		long strength =0, quality = 0;
-		HRESULT hr = ChannelSinalStrength(env, pCapInfo, &strength, &quality, NULL);
+		HRESULT hr = ChannelSignalStrength(env, pCapInfo, &strength, &quality, NULL);
 		slog((env, "DTV Signal Strength=%d %d\r\n", strength, quality));
 		return hr == S_OK ?  quality: 0;
 	}
@@ -821,7 +821,7 @@ HRESULT  RetreveBDAChannel( JNIEnv *env, DShowCaptureInfo* pCapInfo, long *plId1
 }
 
 
-HRESULT  ChannelSinalStrength( JNIEnv *env, DShowCaptureInfo* pCapInfo, long *strength, long* quality, bool* locked )
+HRESULT  ChannelSignalStrength( JNIEnv *env, DShowCaptureInfo* pCapInfo, long *strength, long* quality, bool* locked )
 {
 	HRESULT hr;
 	CComPtr <IBDA_Topology> bdaNetTop;

--- a/native/dll/DShowCapture-2/DeviceDiscovery.cpp
+++ b/native/dll/DShowCapture-2/DeviceDiscovery.cpp
@@ -472,8 +472,15 @@ static int MergeNameList( JNIEnv *env, DEVNAME* DevName, int numDev, DEVNAME* De
                 else if (!strncmp(DevName1[i].FriendlyName, "Hauppauge WinTV 885 TS Capture 2", 32))
                     j = numDev;
 
+				/* ----------------
+				* JRE: hardcode for Hauppauge HVR-4400, which has 2 BDA Receiver Components
+				* (885 TS Capture, 885 Alt TS Capture) for it's 2 BDA Video Capture Sources
+				*
+				*/
+				else if (!strncmp(DevName1[i].FriendlyName, "Hauppauge WinTV 885 Alt TS Capture", 34))
+					j = numDev;
 
-                /* ----------------
+				/* ----------------
                  * KSF: hardcode for Hauppauge WinTV-dualHD usb stick, which has a single 'TS Capture' and 
                  * 2 Source Filters (ATSC Tuner, ATSC Tuner 2) at it's hardware location.
                  * We don't want user to see (or be able to select) the TS Capture device.

--- a/native/dll/DShowCapture-2/SageDTV.cpp
+++ b/native/dll/DShowCapture-2/SageDTV.cpp
@@ -714,7 +714,7 @@ int tuneDVBTFrequency( DShowCaptureInfo* pCapInfo, DVB_T_FREQ* dvbt, int bDryRun
 		}
 		else
 		{
-			flog( ("native.log", "Sucessful Changing DVB-T freq %d band :%d \n", freq, band ) );
+			flog( ("native.log", "Successful Changing DVB-T freq %d band :%d \n", freq, band ) );
 			pCapInfo->dwTuneState = 1;
 		}
 	}
@@ -801,7 +801,7 @@ int tuneDVBCFrequency( DShowCaptureInfo* pCapInfo, DVB_C_FREQ* dvbc, int bDryRun
 		}
 		else
 		{
-			flog( ("native.log", "Sucessful changing DVB-C freq:%d symrate:%d mod:%d fec_in:%d fec_in_rate:%d fec_out:%d fec_out_rate:%d hr=0x%x\n", 
+			flog( ("native.log", "Successful changing DVB-C freq:%d symrate:%d mod:%d fec_in:%d fec_in_rate:%d fec_out:%d fec_out_rate:%d hr=0x%x\n", 
 			             freq, symrate, modulation, innerFEC, innerFECRate, outerFEC, outerFECRate, hr ) );
 			pCapInfo->dwTuneState = 1;
 		}
@@ -954,7 +954,7 @@ int tuneDVBSFrequency( DShowCaptureInfo* pCapInfo, DVB_S_FREQ* dvbs, int bDryRun
 		}
 		else
 		{
-			flog( ("native.log", "Sucessful Changing DVB-S tune request for freq %d symrate:%d mod:%d fec_in:%s fec_in_rate:%s(0x%x) fec_out:%s fec_out_rate:%s pol:%d roll:0x%02x pilot:0x%02x hr=0x%x.\n", 
+			flog( ("native.log", "Successful Changing DVB-S tune request for freq %d symrate:%d mod:%d fec_in:%s fec_in_rate:%s(0x%x) fec_out:%s fec_out_rate:%s pol:%d roll:0x%02x pilot:0x%02x hr=0x%x.\n", 
 				     freq, symrate, modulation, in_fec, in_fec_rate, innerFECRate, out_fec, out_fec_rate, pol, roll_off, pilot, hr ) );
 			pCapInfo->dwTuneState = 1;
 		}

--- a/native/dll/DShowCapture-2/ScanChannel.cpp
+++ b/native/dll/DShowCapture-2/ScanChannel.cpp
@@ -28,7 +28,7 @@
 extern FilterGraphTools graphTools;
 TV_TYPE GetTVType( DShowCaptureInfo *pCapInfo );
 char * TVTypeString( TV_TYPE BDATVType );
-HRESULT  ChannelSinalStrength( JNIEnv *env, DShowCaptureInfo* pCapInfo, long *strength, long* quality, bool* locked );
+HRESULT  ChannelSignalStrength( JNIEnv *env, DShowCaptureInfo* pCapInfo, long *strength, long* quality, bool* locked );
 HRESULT  ChangeATSCChannel( JNIEnv *env, DShowCaptureInfo* pCapInfo, long lPhysicalChannel,long lMajorChannel, long lMinorChannel );
 HRESULT  SetupBDAStreamOutFormat( JNIEnv *env, DShowCaptureInfo* pCapInfo, int streamType );
 

--- a/native/dll/DShowCapture-2/TunerPlugin.cpp
+++ b/native/dll/DShowCapture-2/TunerPlugin.cpp
@@ -104,7 +104,7 @@ int  SetupTunerPlugin( JNIEnv *env, DShowCaptureInfo* pCapInfo, int nTunerType )
 		ret = RegQueryValueEx( hregkey, PluginKey, 0, &hType, (LPBYTE)&PluginName, &hSize);
 		if ( ret )
 		{
-			slog((env, "Tuner Plugin is not specified in registery '%s\\%s' \r\n", regkey, PluginKey ));
+			slog((env, "Tuner Plugin is not specified in registry '%s\\%s' \r\n", regkey, PluginKey ));
 			PluginName[0] = 0;
 			ret = -2;
 		} 
@@ -112,7 +112,7 @@ int  SetupTunerPlugin( JNIEnv *env, DShowCaptureInfo* pCapInfo, int nTunerType )
 	} 
 	else
 	{
-		slog((env, "Tuner Plugin not setup in registery '%s' \r\n", regkey ));
+		slog((env, "Tuner Plugin not setup in registry '%s' \r\n", regkey ));
 		ret = -3;
 	}
 

--- a/native/dll/Win32DLL/SageTVWin32DLL.cpp
+++ b/native/dll/Win32DLL/SageTVWin32DLL.cpp
@@ -1245,7 +1245,7 @@ JNIEXPORT jboolean JNICALL Java_sage_Sage_setupSystemHooks0
 		if ( !ret )
 		{
 			Win32ShellHookEnable = dwEnable;
-			elog((env, "specifiy Win32ShellHookEnable Enable %d in registery\r\n", Win32ShellHookEnable ));
+			elog((env, "specify Win32ShellHookEnable Enable %d in registry\r\n", Win32ShellHookEnable ));
 		} 
 		RegCloseKey( hregkey );
 	}
@@ -1275,7 +1275,7 @@ JNIEXPORT jboolean JNICALL Java_sage_Sage_setupSystemHooks0
 				// Check that it worked
 				if (hookRes)
 				{
-					slog((env, "Succesfully setup system shell hook\r\n"));
+					slog((env, "Successfully setup system shell hook\r\n"));
 				}
 				else
 				{
@@ -1308,7 +1308,7 @@ JNIEXPORT jboolean JNICALL Java_sage_Sage_setupSystemHooks0
 				if ( !ret )
 				{
 					WinRawInputEnable = dwEnable;
-					elog((env, "specifiy RawInputHook Enable %d in registery\r\n", WinRawInputEnable ));
+					elog((env, "specify RawInputHook Enable %d in registry\r\n", WinRawInputEnable ));
 				} 
 				RegCloseKey( hregkey );
 			}
@@ -1335,7 +1335,7 @@ JNIEXPORT jboolean JNICALL Java_sage_Sage_setupSystemHooks0
 				hookRes = lpfnProc((HWND) jhwnd);
 				if (hookRes)
 				{
-					slog((env, "Succesfully setup win raw input\r\n" ));
+					slog((env, "Successfully setup win raw input\r\n" ));
 				}
 				else
 				{
@@ -1347,29 +1347,29 @@ JNIEXPORT jboolean JNICALL Java_sage_Sage_setupSystemHooks0
 		}
 	}
 
-	char KeybooardHookName[100]={0};
+	char KeyboardHookName[100]={0};
 	if ( RegOpenKeyEx(HKEY_LOCAL_MACHINE, regkey, 0, KEY_READ, &hregkey) == ERROR_SUCCESS )
 	{
 		DWORD hType;
-		DWORD hSize = sizeof(KeybooardHookName);
-		ret = RegQueryValueEx( hregkey, "WinKeyboardHook", 0, &hType, (LPBYTE)KeybooardHookName, &hSize);
+		DWORD hSize = sizeof(KeyboardHookName);
+		ret = RegQueryValueEx( hregkey, "WinKeyboardHook", 0, &hType, (LPBYTE)KeyboardHookName, &hSize);
 		if ( ret )
 		{
-			//strcpy( KeybooardHookName, "WinKeyboardHook" );
-			elog((env, "not specifiy WinkeyboardHook in registery, load default one\r\n"));
+			//strcpy( KeyboardHookName, "WinKeyboardHook" );
+			elog((env, "no specific WinkeyboardHook in registry, load default one\r\n"));
 		} else
 		{
-			elog((env, "load specifiy WinkeyboardHook in registry '%s'\r\n", KeybooardHookName ));
+			elog((env, "load specific WinkeyboardHook in registry '%s'\r\n", KeyboardHookName ));
 		}
 		RegCloseKey( hregkey );
 	}
 
-	if ( KeybooardHookName[0] )
+	if ( KeyboardHookName[0] )
 	{
-		hKeybaordLib= LoadLibrary(KeybooardHookName);
+		hKeybaordLib= LoadLibrary(KeyboardHookName);
 		if (!hKeybaordLib)
 		{
-			elog((env, "ERROR Unable to load WinKeyboardHook library:%s\r\n", KeybooardHookName ));
+			elog((env, "ERROR Unable to load WinKeyboardHook library:%s\r\n", KeyboardHookName ));
 			ret = JNI_FALSE;
 		} else
 		{
@@ -1383,12 +1383,12 @@ JNIEXPORT jboolean JNICALL Java_sage_Sage_setupSystemHooks0
 				hookRes = lpfnProc((HWND) jhwnd);
 				if (hookRes)
 				{
-					slog((env, "Succesfully setup WinKeyborad hook\r\n"));
+					slog((env, "Successfully setup WinKeyboard hook\r\n"));
 				}
 				else
 				{
 					// The hook failed
-					elog((env, "Failed setting up WinKeyborad hook\r\n"));
+					elog((env, "Failed setting up WinKeyboard hook\r\n"));
 					ret = JNI_FALSE;
 				}
 			}


### PR DESCRIPTION
Hauppauge HVR-4400 and other 885 hybrid variants contain Hauppauge Alt TS Capture for DVB-S/S2 and Hauppauge TS Capture for DVB-T/T2
This change allows selecting the Hauppauge 885 Alt TS Capture device to add the DVB-S/S2 tuner
and allows selecting the Hauppauge 885 Video Capture device to add the DVB-T/T2 tuner

Fix typos while doing code review