### PR TITLE
Fix: Sage-x64 hang due to CableCARD tuners (Windows)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Change Log
 
+* Fix: Sage-x64 hang due to CableCARD tuners (Windows)
 * Fix: Add support for HVR-4400 and other 885 variants (Windows) 
 
 ## Version 9.1.10 (2018-10-13)

--- a/native/dll/DShowCapture-2/FilterGraphTools.cpp
+++ b/native/dll/DShowCapture-2/FilterGraphTools.cpp
@@ -202,6 +202,27 @@ HRESULT FilterGraphTools::AddFilterByDevicePath2(IGraphBuilder* piGraphBuilder, 
 	//{
 	//	return AddFilterByDevicePath( piGraphBuilder, ppiFilter, pDevicePath, pName );
 	//}
+
+    /* These tuners are a mess.  
+    On Win-x64, their installers didn't make 32-bit entries for them in
+    HKEY_CLASSES_ROOT\Wow6432Node\CLSID\{FD0A5AF4-B41D-11D2-9C95-00C04F7971E0}\Instance
+    (BDA Receiver Components), nor are there entries in
+    HKEY_CLASSES_ROOT\Wow6432Node\CLSID\{71985F48-1CA1-11d3-9CC8-00C04F7971E0}\Instance
+    (BDA Source Filters), so Sage-x86 on 64-bit Windows doesn't encounter them.
+    But they DO have 64-bit registry entries for BDA Receiver Components & BDA Source Filters
+    in  HKEY_CLASSES_ROOT\CLSID\{FD0A5AF4-B41D-11D2-9C95-00C04F7971E0}\Instance
+    and HKEY_CLASSES_ROOT\CLSID\{71985F48-1CA1-11d3-9CC8-00C04F7971E0}\Instance
+    so Sage-x64 does see these.  When we find these filter keys, it takes nearly 30 seconds
+    on every attempt to add the filter.  Since we don't natively handle CableCARD
+    tuners anyway (requires a *DCT shim), the best solution is to ignore them here.
+    */
+    if ((wcsncmp(pName, L"HDHomeRun Prime Tuner", 21) == 0) ||
+        (wcsncmp(pName, L"Ceton InfiniTV PCIe", 19) == 0))
+    {
+        Log(L"Hardcode: ignore CableCARD tuner '%s' \r\n", pName);
+        return (E_FAIL);
+    }
+
 	//software device
 	hr = AddFilterByDevicePath( piGraphBuilder, ppiFilter, pDevicePath, pName );
 	if ( hr != S_OK )


### PR DESCRIPTION
This issue was discovered during beta testing of Sage-x64 Windows installer v1.103.

Sage-x64 can encounter thread-hangs when Ceton InfiniTV or HdHomeRun Prime CableCARD tuners are currently installed or have previously been installed in the computer.  HDHR (ClearQAM) tuners don't encounter the problem.

Symptoms:
1) Disk Space Bar in the GUI takes several minutes to update after Sage initially starts up.  A test system with one HDHR Prime and one Ceton InfiniTv took nearly 25 minutes for the Disk Space Bar to update.
2) System Messages may log "Recording Missed Due to Capture Device Failure" at the beginning of a recording, but the recording eventally does start after approx. 30 seconds (or more).
3) Inspection of SageTv_0.txt log reveals thread hangs (usually MainMsg) for nearly 30 seconds at a time.  This occurs repeatedly, typically preceded by a "Failed to add BDA tuner" log entry.
4) Shutting down Sage takes many minutes, with Windows reporting the service didn't respond to the request.  Manually killing the SageTvService via TaskManager is usually required.
5) Removing the HDHR Prime and Ceton hardware, drivers and software doesn't avoid the hang, because the registry keys for these tuners are still present.

Analysis:
The presence of Ceton or HDHomeRun Prime (CableCARD) tuner filter registry keys results in a thread hang with each attempt to add a filter for them.  The hang can last nearly 30 seconds on each attempt.   

Background:
On Win-x64, the installers for these tuners didn't make 32-bit entries for them in
 HKEY_CLASSES_ROOT\Wow6432Node\CLSID\{FD0A5AF4-B41D-11D2-9C95-00C04F7971E0}\Instance
    (BDA Receiver Components), nor are there entries in
 HKEY_CLASSES_ROOT\Wow6432Node\CLSID\{71985F48-1CA1-11d3-9CC8-00C04F7971E0}\Instance
    (BDA Source Filters), so Sage-x86 on 64-bit Windows doesn't encounter them.

But they DO have 64-bit registry entries for BDA Receiver Components & BDA Source Filters
  in  HKEY_CLASSES_ROOT\CLSID\{FD0A5AF4-B41D-11D2-9C95-00C04F7971E0}\Instance
  and HKEY_CLASSES_ROOT\CLSID\{71985F48-1CA1-11d3-9CC8-00C04F7971E0}\Instance,
so Sage-x64 does see these.  When we find these filter keys, it takes nearly 30 seconds on every attempt to add the filter.  Since we don't natively handle CableCARD tuners anyway (requires a *DCT shim), the best solution is to completely ignore them.


This pull request resolves the issue.

The fix has been tested with HDHR Prime and Ceton InfiniTV-4 tuners, and SageDCT.
