### PR TITLE
Fix: IR interface hangs trying to send non-numeric (eg: 42-1-1) command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Change Log
-
+* Fix: IR interface hangs trying to send non-numeric (eg: 42-1-1) command.
 * Fix: Sage-x64 hang due to CableCARD tuners (Windows)
 * Fix: Add support for HVR-4400 and other 885 variants (Windows) 
 

--- a/java/sage/SFIRTuner.java
+++ b/java/sage/SFIRTuner.java
@@ -601,9 +601,21 @@ public class SFIRTuner implements Runnable
     {
       if (Sage.DBG) System.out.println("Playing IR tune command of " + cmdString);
       if (!ensureRemoteLoaded(remoteName)) return;
+
+      try {
+         int cmdNum = Integer.parseInt(cmdString);
+      } catch (Exception e) {
+         String cmdStringNumeric = cmdString.replaceAll("\\D", ""); // remove all non-digits
+	 cmdString = cmdStringNumeric;
+         if (Sage.DBG) System.out.println("IR tune command must be all digits; converted it to: " + cmdString);
+      }
+
       if (canMacroTune())
       {
-        macroTune(Integer.parseInt(cmdString));
+	try {
+          macroTune(Integer.parseInt(cmdString));
+	}
+        catch (Exception e){}
       }
       else
       {


### PR DESCRIPTION
Symptoms:
Any attempt to send a non-numeric IR tuning command (eg: 2.1 or 42-1-1) to the IR blaster prevents sending any further IR commands, including numeric-only commands.  There's no indication of the failure in the UI, nor is anything logged to indicate a problem.  From the user's standpoint, IR Tx just stops.  A restart of Sage is then needed to allow sending even numeric-only IR commands again, which makes it extremely difficult to debug the problem.

The problem exists in all previous releases of Sage.  It was discovered during beta testing contributor wnjj's x64 implementation of IR blaster support for USB-UIRT & Hauppauge, for the Sage-x64 Windows installer.  

Analysis:
In playTuneString(), an unhandled exception occurs in Integer.parseInt(cmdString) when it encounters a tuning string with non-numeric characters.  This prevents subsequent conversion of string -> numeric.

Changes implemented:
1- Added the missing exception handler, which probably shouldn't occur in the future because....
2- Added an enhancement to automatically strip any non-numeric characters from the cmdString, so that purely numeric values are passed to the 3rd-party blaster code.  This avoids the need for the user to have to manually edit (remap) any Physical Channel value in Tuner Setup.  The conversion is logged.

Testing:
This fix has been regression tested on Sage-x86 and Sage-x64.

Thanks to forum user & contributor wnjj for his help pointing me to the relevant section of the code.