### PR TITLE
Fix Windows 64-bit music visualizer and AVI playback crashes.

### DIFF
--- a/native/dll/DShowPlayer-2/MusicVisualizer.cpp
+++ b/native/dll/DShowPlayer-2/MusicVisualizer.cpp
@@ -22,7 +22,8 @@
 #include "sage_DShowMediaPlayer.h"
 #include "imusicvis.h"
 #include "guids.h"
-#include <jawt_md.h>
+#pragma pack(push, 16)  // align JAWT data struct to DLL call
+#include "jawt_md.h"
 #include "sage_PlaybackException.h"
 
 #define MUSIC_DATA_HIST_LEN 200
@@ -346,7 +347,14 @@ JNIEXPORT void JNICALL Java_sage_DShowMusicPlayer_renderVisualization0
 		typedef jboolean (JNICALL *AWTPROC)(JNIEnv* env, JAWT* awt);
 		
 		awt.version = JAWT_VERSION_1_3;
-		AWTPROC lpfnProc = (AWTPROC)GetProcAddress(sageLoadedAwtLib, "_JAWT_GetAWT@8");
+#ifdef _WIN64
+    AWTPROC lpfnProc = (AWTPROC)GetProcAddress(sageLoadedAwtLib, "JAWT_GetAWT");
+#else
+    AWTPROC lpfnProc = (AWTPROC)GetProcAddress(sageLoadedAwtLib, "_JAWT_GetAWT@8");
+#endif
+    if (lpfnProc == NULL)
+      return;
+
 		result = lpfnProc(env, &awt);
 		if (result == JNI_FALSE)
 			return;
@@ -409,3 +417,4 @@ JNIEXPORT void JNICALL Java_sage_DShowMusicPlayer_renderVisualization0
 		elog((env, "EXCEPTION ERROR in renderVisualization.\r\n"));
 	}
 }
+#pragma pack(pop)

--- a/native/dll/Win32DLL/SageTVWin32DLL.cpp
+++ b/native/dll/Win32DLL/SageTVWin32DLL.cpp
@@ -23,6 +23,7 @@
 #include "../../include/sage_UserEvent.h"
 #include <wininet.h>
 #include <shellapi.h>
+#pragma pack(push, 16)  // align JAWT data struct to DLL call
 #include "jawt.h"
 #include "jawt_md.h"
 
@@ -1639,3 +1640,4 @@ BOOL APIENTRY DllMain( HANDLE hModule,
     return TRUE;
 }
 
+#pragma pack(pop)

--- a/third_party/Microsoft/FileSource/AsyncIO.cpp
+++ b/third_party/Microsoft/FileSource/AsyncIO.cpp
@@ -30,7 +30,7 @@ CAsyncRequest::Request(
     BOOL bAligned,
     BYTE* pBuffer,
     LPVOID pContext,	// filter's context
-    DWORD dwUser)	// downstream filter's context
+    DWORD_PTR dwUser)	// downstream filter's context
 {
     m_pAsyncIO = pIo;
     m_pStream = pStream;
@@ -159,7 +159,7 @@ CAsyncIo::Request(
             BOOL bAligned,
             BYTE* pBuffer,
             LPVOID pContext,
-            DWORD dwUser)
+            DWORD_PTR dwUser)
 {
     if (bAligned) {
         if (!IsAligned(llPos) ||

--- a/third_party/Microsoft/FileSource/AsyncIO.h
+++ b/third_party/Microsoft/FileSource/AsyncIO.h
@@ -37,7 +37,7 @@ class CAsyncRequest
     LONG		m_lLength;
     BYTE* 		m_pBuffer;
     LPVOID 		m_pContext;
-    DWORD		m_dwUser;
+    DWORD_PTR	m_dwUser;
     HRESULT     m_hr;
 
 public:
@@ -51,7 +51,7 @@ public:
 		BOOL   bAligned,
 		BYTE*  pBuffer,
 		LPVOID pContext,	// filter's context
-		DWORD  dwUser );		// downstream filter's context
+		DWORD_PTR dwUser );		// downstream filter's context
 
     // issue the i/o if not overlapped, and block until i/o complete.
     // returns error code of file i/o
@@ -69,7 +69,7 @@ public:
 		return m_pContext;
 	};
 
-	DWORD GetUser()
+	DWORD_PTR GetUser()
 	{
 		return m_dwUser;
 	};
@@ -199,7 +199,7 @@ public:
                 BOOL bAligned,
 		BYTE* pBuffer,
 		LPVOID pContext,
-		DWORD dwUser);
+		DWORD_PTR dwUser);
 
     // wait for the next read to complete
     HRESULT WaitForNext(


### PR DESCRIPTION
This fixes 2 more 64-bit Windows issues:  1. The music visualizer would crash when started.  2. AVI playback would crash on some systems.  The music fix needed a 64-bit specific DLL function call plus a struct 'pack' pragma to align with the Java DLL's expectation.  I added the same 'pack' to the other place we use the same struct even though it was already defaulting to the right size, in case a future code change affects that default.  The AVI fix was in the File Source filter where downstream filter context reference needed to be a DWORD_PTR instead of a DWORD.  Tested by me and 2 other users.