### PR TITLE
Fix DirecTVSerialControl not working in 9.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+dist: trusty
 
 jdk:
   - oraclejdk8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+* Fix DirecTVSerialControl
+* Fix 64-bit service launcher (Windows)
+* Set default 1G heap for 64-bit (Windows)
 * Updates for OPTUS D1 transponder changes to DVB-S2
 
 ## Version 9.2.1 (2019-03-23)

--- a/java/sage/DirecTVSerialControl.java
+++ b/java/sage/DirecTVSerialControl.java
@@ -32,7 +32,7 @@ public class DirecTVSerialControl
       while (walker.hasNext())
       {
         Long currHandle = (Long) walker.next();
-        closeHandle0(currHandle.intValue());
+        closeHandle0(currHandle);
         // Don't forget to remove it since its no longer valid!
         walker.remove();
       }

--- a/native/dll/DirecTVSerialControl/DirecTVSerialControl.cpp
+++ b/native/dll/DirecTVSerialControl/DirecTVSerialControl.cpp
@@ -190,7 +190,7 @@ static int nonblock_write(int fd, void *buf, size_t count)
 static int initdCmdData = 0;
 static int dtvCmdStyle[NUM_CMD_STYLE_SLOTS];
 static jint channelBase[NUM_CMD_STYLE_SLOTS];
-static jint portHandles[NUM_CMD_STYLE_SLOTS];
+static jlong portHandles[NUM_CMD_STYLE_SLOTS];
 static int confirmedChannelBase[NUM_CMD_STYLE_SLOTS];
 
 /*
@@ -483,7 +483,7 @@ JNIEXPORT jlong JNICALL Java_sage_DirecTVSerialControl_openDTVSerial0
 		if (portHandles[i] == 0)
 		{
 			cmdStyleIndex = i;
-			portHandles[i] = (jint) comHandle;
+			portHandles[i] = comHandle;
 			break;
 		}
 	}
@@ -595,7 +595,7 @@ slog((env, "DTVSerialX num=%d cmd[0]=0x%x.\r\n", num, cmd[0]));
 /*
  * Class:     sage_DirecTVSerialControl
  * Method:    closeHandle0
- * Signature: (I)V
+ * Signature: (J)V
  */
 JNIEXPORT void JNICALL Java_sage_DirecTVSerialControl_closeHandle0
   (JNIEnv *env, jobject jo, jlong jhand)
@@ -622,7 +622,7 @@ JNIEXPORT void JNICALL Java_sage_DirecTVSerialControl_closeHandle0
 /*
  * Class:     sage_DirecTVSerialControl
  * Method:    dtvSerialChannel0
- * Signature: (II)Z
+ * Signature: (JI)Z
  */
 JNIEXPORT jboolean JNICALL Java_sage_DirecTVSerialControl_dtvSerialChannel0
   (JNIEnv *env, jobject jo, jlong comHandle, jint channel)

--- a/native/include/sage_DirecTVSerialControl.h
+++ b/native/include/sage_DirecTVSerialControl.h
@@ -19,18 +19,18 @@ JNIEXPORT jlong JNICALL Java_sage_DirecTVSerialControl_openDTVSerial0
 /*
  * Class:     sage_DirecTVSerialControl
  * Method:    closeHandle0
- * Signature: (I)V
+ * Signature: (J)V
  */
 JNIEXPORT void JNICALL Java_sage_DirecTVSerialControl_closeHandle0
-  (JNIEnv *, jobject, jint);
+  (JNIEnv *, jobject, jlong);
 
 /*
  * Class:     sage_DirecTVSerialControl
  * Method:    dtvSerialChannel0
- * Signature: (II)Z
+ * Signature: (JI)Z
  */
 JNIEXPORT jboolean JNICALL Java_sage_DirecTVSerialControl_dtvSerialChannel0
-  (JNIEnv *, jobject, jint, jint);
+  (JNIEnv *, jobject, jlong, jint);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
64-bit changes broke DirecTVSerialControl (handle size mismatches).  Forum thread here:  https://forums.sagetv.com/forums/showthread.php?t=66130  Confirmed fixed by 2 users.

Also updated the changelog to include the previous Windows service launcher fix.