### PR TITLE
Schedules Direct EPG grabber failed to finish updating some satellite-based lineups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Fix 64-bit service launcher (Windows)
 * Set default 1G heap for 64-bit (Windows)
 * Updates for OPTUS D1 transponder changes to DVB-S2
+* Fix: Schedules Direct EPG grabber failed to finish updating some satellite-based lineups 
 
 ## Version 9.2.1 (2019-03-23)
 * 64-bit AVI playback and music fixes (Windows)

--- a/java/sage/epg/sd/json/map/channel/SDAdvancedChannelMap.java
+++ b/java/sage/epg/sd/json/map/channel/SDAdvancedChannelMap.java
@@ -20,7 +20,7 @@ import sage.epg.sd.json.map.SDChannelMap;
 public class SDAdvancedChannelMap extends SDChannelMap
 {
   // Source: http://forums.schedulesdirect.org/viewtopic.php?f=17&t=2722&p=8917
-  private int frequencyHz;
+  private long frequencyHz;
   private String polarization;
   private String deliverySystem; // (DVB-C, DVB-S, DVB-T, ATSC)
   private String modulationSystem; // (QPSK, QAM64, QAM256, 8VSB)
@@ -42,7 +42,7 @@ public class SDAdvancedChannelMap extends SDChannelMap
   private int channelMinor;
   private String matchType; // (providerChannel, providerCallsign, logicalChannelNumber)
 
-  public int getFrequencyHz()
+  public long getFrequencyHz()
   {
     return frequencyHz;
   }


### PR DESCRIPTION
This fixes a rare issue that currently only plagues one user. Basically the integer from Schedules Direct is an unsigned integer, but Java only does signed. The easiest way to work around this is to either not import the frequencyHz variable from their JSON reply or make it a long integer. I chose the later since the extra data might be useful down the road even though we don't use it now.