### PR TITLE
Fix for Hauppauge 885 tuners with Alt TS Capture Devices (Windows)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Change Log
 
+* Fix for Hauppauge 885 tuners with Alt TS Capture Devices (Windows)
 * Change maximum number of BDA tuners from 2 to 4 (HVR-5525 has 3 BDA tuners)
 * Fix DirecTVSerialControl
 * Fix 64-bit service launcher (Windows)
 * Set default 1G heap for 64-bit (Windows)
 * Updates for OPTUS D1 transponder changes to DVB-S2
-* Fix: Schedules Direct EPG grabber failed to finish updating some satellite-based lineups 
+* Fix: Schedules Direct EPG grabber failed to finish updating some satellite-based lineups
 
 ## Version 9.2.1 (2019-03-23)
 * 64-bit AVI playback and music fixes (Windows)

--- a/native/dll/DShowCapture-2/DeviceDiscovery.cpp
+++ b/native/dll/DShowCapture-2/DeviceDiscovery.cpp
@@ -389,7 +389,7 @@ static int PurgeNameList( JNIEnv *env, DEVNAME* DevName, int numDev, REFCLSID de
     Return: resultant number of elements in DevName[]
 
     Notes: Overall, the general assumtion is that a given Video Capture Source will only have a 
-        single BDA Reciever Component associated with it at the Source's hardware_loc.
+        single BDA Receiver Component associated with it at the Source's hardware_loc.
         "Hybrid" Video Capture Sources have multiple Receivers at a given hardware_loc, 
         but they can't be used at the same time.
         Here we also handle a few special cases that DO have multiple Receivers associated with
@@ -461,7 +461,7 @@ static int MergeNameList( JNIEnv *env, DEVNAME* DevName, int numDev, DEVNAME* De
 
 
                 /* ----------------
-                 * KSF: hardcode for Hauppauge WinTV-quadHD, which has 2 BDA Reciever Components 
+                 * KSF: hardcode for Hauppauge WinTV-quadHD, which has 2 BDA Receiver Components 
                  * (885 TS Capture, 885 TS Capture 2) for both of it's 2 Video Capture Sources
                  * (i.e., at both of it's 2 PCIe hardware locations).
                  *
@@ -473,9 +473,10 @@ static int MergeNameList( JNIEnv *env, DEVNAME* DevName, int numDev, DEVNAME* De
                     j = numDev;
 
 				/* ----------------
-				* JRE: hardcode for Hauppauge HVR-4400, which has 2 BDA Receiver Components
-				* (885 TS Capture, 885 Alt TS Capture) for it's 2 BDA Video Capture Sources
-				*
+				* JRE: hardcode for Hauppauge 885 AltBDATunerModels (HVR-3300, HVR-4400, HVR-5500, HVR-4400, HVR-5505, HVR-4405, HVR-5525),
+				* which have 2 BDA Receiver Components (885 TS Capture, with a hybrid tuner and 885 Alt TS Capture, with a DVBS2 tuner)
+				* Hauppauge WinTV 885 TS Capture should have all tuners except DVB-S/S2
+				* Hauppauge WinTV 885 Alt TS Capture should only have DVB-S/S2
 				*/
 				else if (!strncmp(DevName1[i].FriendlyName, "Hauppauge WinTV 885 Alt TS Capture", 34))
 					j = numDev;
@@ -557,7 +558,7 @@ static int MergeNameList( JNIEnv *env, DEVNAME* DevName, int numDev, DEVNAME* De
 				SPRINTF( NewCaptureName, sizeof(NewCaptureName) , "%s<%s>-%d", szHybridCapture, TunerType, DevName[num-1].index  ); 
 			slog((env, "found hybrid tuner '%s' for '%s' #%d (%d)\r\n", NewCaptureName,
 				                                    DevName[num-1].FriendlyName, DevName[num-1].index, num-1 ) );
-			bool IsHybrideTuner = true;
+			bool IsHybridTuner = true;
 
 			char FilterName[256]={0};
 			if ( CheckFakeBDACrossBar( env, NewCaptureName, DevName[num-1].index, FilterName, sizeof( FilterName ) ) )
@@ -569,21 +570,21 @@ static int MergeNameList( JNIEnv *env, DEVNAME* DevName, int numDev, DEVNAME* De
 					if ( strstr( CaptureDrvInfo.device_desc, "HVR-1250") || strstr( CaptureDrvInfo.device_desc, "HVR-1255") ||
 						 strstr( CaptureDrvInfo.device_desc, "HVR-1550")  )
 					{
-						slog((env, "it's a HVR-1250 share tuner, not a real hybride tuner! (%s) \r\n", CaptureDrvInfo.device_desc ) );				
-						IsHybrideTuner = false;
+						slog((env, "it's a HVR-1250 share tuner, not a real hybrid tuner! (%s) \r\n", CaptureDrvInfo.device_desc ) );				
+						IsHybridTuner = false;
 					} else
 					{
-						slog((env, "It's a hybride tuner %s '%s'. \r\n", NewCaptureName, CaptureDrvInfo.device_desc ) );				
+						slog((env, "It's a hybrid tuner %s '%s'. \r\n", NewCaptureName, CaptureDrvInfo.device_desc ) );				
 					}
 				} else
 				{
 					DEVICE_DRV_INF  CaptureDrvInfo={0};
 					GetDeviceInfo( FilterName, &CaptureDrvInfo );
-					slog((env, "It's a hybride tuner %s '%s'. \r\n", NewCaptureName, CaptureDrvInfo.device_desc ) );					
+					slog((env, "It's a hybrid tuner %s '%s'. \r\n", NewCaptureName, CaptureDrvInfo.device_desc ) );					
 				}
 			}
 
-			if ( IsHybrideTuner )
+			if ( IsHybridTuner )
 			{
 				 //add a hybrid tuner into device list
 				strncpy( DevName[num].FriendlyName, NewCaptureName, sizeof(DevName[num].FriendlyName) );

--- a/native/dll/DShowCapture-2/DeviceVerify.cpp
+++ b/native/dll/DShowCapture-2/DeviceVerify.cpp
@@ -842,7 +842,7 @@ JNIEXPORT jint JNICALL Java_sage_DShowCaptureDevice_getDeviceCaps0
 	//Processing Hauppauge tuners
 	if ( hcw && bFoundDevice )
 	{
-		slog((env, "It's Hauppauge device.\r\n") );
+		slog((env, "It's a Hauppauge device.\r\n") );
 		if ( strstr( CaptureDrvInfo.device_desc, "HVR-1250") || strstr( CaptureDrvInfo.device_desc, "HVR-1255") || 
 			 strstr( CaptureDrvInfo.device_desc, "HVR-1550") )
 		{  
@@ -876,31 +876,83 @@ JNIEXPORT jint JNICALL Java_sage_DShowCaptureDevice_getDeviceCaps0
 		}
 		else
 
-		// hard code for HVR-4400 and (3300, 5500, 4405,5505)? desc:"Hauppauge WinTV HVR-4400 (Model 121xxx, Hybrid DVB-T/S2, IR)"
-		// it's a hybrid, but has DVB-T and DVB-S connected to two different TS Capture filters
-		if ( strstr(CaptureDrvInfo.device_desc, "Hybrid DVB-T/S"))
+		// hard code for HVR-4400, 3300 and 4405. desc:"Model 121xxx, Hybrid DVB-T/S2" and "Model 53xxx, Hybrid DVB-T/S"
+		// it has two different TS Capture filters, one with DVB-T and one with DVB-S 
+		// This still needs more work as the Analog capture doesn't work
+		if (strstr(CaptureDrvInfo.device_desc, "Model 121xxx, Hybrid DVB-T/S2") || strstr(CaptureDrvInfo.device_desc, "Model 53xxx, Hybrid DVB-T/S"))
 		{
 			isHybridCapture = false;
 			hasCaptureDetails = false;
 			detailsCaptureMask = 0x000800;  // sage_DShowCaptureDevice_MPEG_AV_CAPTURE_MASK
 			detailsChipsetMask = 0;
-			BDAInputType = sage_DShowCaptureDevice_BDA_DVB_S | sage_DShowCaptureDevice_BDA_DVB_T;
-			slog((env, "A bundle card is found (Analog+DVB-T+DVB-S), DVB-T|DVB-S added into source.\r\n"));
+			if (strstr(capFiltName, "Hauppauge WinTV 885 Alt TS Capture"))
+			// set up DVB-S on Hauppauge WinTV 885 Alt TS Capture
+			{
+				BDAInputType = sage_DShowCaptureDevice_BDA_DVB_S;
+				slog((env, "An AltBDATunerModel tuner card is found, DVB-S added into source.\r\n"));
+			}
+			else
+			if (strstr(capFiltName, "Hauppauge WinTV 885 TS Capture"))
+			// set up DVB-T on Hauppauge WinTV 885 TS Capture
+			{
+				BDAInputType = sage_DShowCaptureDevice_BDA_DVB_T;
+				slog((env, "A bundle card is found (Analog+DVB-T), DVB-T added into source.\r\n"));
+			}
 		}
 		else
 
-		// hard code for HVR-5525 desc:"Hybrid DVB-T/C/S2, IR)"
-		// it's a hybrid, but has DVB-T,DVB-C and DVB-S connected to two different TS Capture filters
-		if (strstr(CaptureDrvInfo.device_desc, "Hybrid DVB-T/C"))
+		// hard code for HVR-5525, 5500 and 5505. desc:"Model 150xxx, Hybrid DVB-T/T2/C/S2" and "Model 121xxx, Hybrid DVB-T/C/S2"
+		// it has two different TS Capture filters, one hybrid with DVB-T and DVB-C and one with DVB-S
+		// This still needs more work as the Analog capture doesn't work
+		if (strstr(CaptureDrvInfo.device_desc, "Model 150xxx, Hybrid DVB-T/T2/C/S2") || strstr(CaptureDrvInfo.device_desc, "Model 121xxx, Hybrid DVB-T/C/S2"))
 		{
 			isHybridCapture = false;
 			hasCaptureDetails = false;
 			detailsCaptureMask = 0x000800;  // sage_DShowCaptureDevice_MPEG_AV_CAPTURE_MASK
 			detailsChipsetMask = 0;
-			BDAInputType = sage_DShowCaptureDevice_BDA_DVB_S | sage_DShowCaptureDevice_BDA_DVB_T | sage_DShowCaptureDevice_BDA_DVB_C;
-			slog((env, "A bundle card is found (Analog+DVB-T+DVB-S+DVB-C), DVB-T|DVB-S|DVB-C added into source.\r\n"));
+			if (strstr(capFiltName, "Hauppauge WinTV 885 Alt TS Capture"))
+			// set up DVB-S on Hauppauge WinTV 885 Alt TS Capture
+			{
+				BDAInputType = sage_DShowCaptureDevice_BDA_DVB_S;
+				slog((env, "An AltBDATunerModel tuner card is found, DVB-S added into source.\r\n"));
+			}
+			else
+			if (strstr(capFiltName, "Hauppauge WinTV 885 TS Capture"))
+			// set up DVB-T & DVB-C on Hauppauge WinTV 885 TS Capture
+			{
+				BDAInputType = sage_DShowCaptureDevice_BDA_DVB_T | sage_DShowCaptureDevice_BDA_DVB_C;
+				slog((env, "A bundle card is found (Analog+DVB-T+DVB-C), DVB-T|DVB-C added into source.\r\n"));
+			}
 		}
 		else
+
+		// hard code for HVR-2200, 2210 and 2205. desc:"WinTV-HVR-2210", "WinTV-HVR-2200"and "WinTV-HVR-2205"
+		// it's a multi-tuner DVB-T but takes takes a long time to initialize as it steps through all the BDA tuners types to find DVB-T
+		if (strstr(CaptureDrvInfo.device_desc, "HVR-2200") || strstr(CaptureDrvInfo.device_desc, "HVR-2210") || strstr(CaptureDrvInfo.device_desc, "HVR-2205"))
+		{
+			isHybridCapture = false;
+			hasCaptureDetails = false;
+			detailsCaptureMask = 0x000800;  // sage_DShowCaptureDevice_MPEG_AV_CAPTURE_MASK
+			detailsChipsetMask = 0;
+			BDAInputType = sage_DShowCaptureDevice_BDA_DVB_T;
+			slog((env, "A multi-tuner card is found (Analog+DVB-T), 2 x DVB-T added into source.\r\n"));
+		}
+		else
+
+		// hard code for WinTV-quadHD. desc:"Dual DVB-T/T2/C"
+		// it's a hybrid, with DVB-T and DVB-C
+//		Needs testing
+//		if (strstr(CaptureDrvInfo.device_desc, "1662xx-1, Dual DVB-T/T2/C,") || strstr(CaptureDrvInfo.device_desc, "1661xx-1, Dual DVB-T/T2/C,") || 
+//			strstr(CaptureDrvInfo.device_desc, "1662xx-2, Dual DVB-T/T2/C)") || strstr(CaptureDrvInfo.device_desc, "1661xx-2, Dual DVB-T/T2/C)"))
+//		{
+//			isHybridCapture = false;
+//			hasCaptureDetails = false;
+//			detailsCaptureMask = 0x000800;  // sage_DShowCaptureDevice_MPEG_AV_CAPTURE_MASK
+//			detailsChipsetMask = 0;
+//			BDAInputType = sage_DShowCaptureDevice_BDA_DVB_T | sage_DShowCaptureDevice_BDA_DVB_C;
+//			slog((env, "A bundle card is found (DVB-T+DVB-C), DVB-T|DVB-C added into source.\r\n"));
+//		}
+//		else
 
 		if ( strstr( CaptureDrvInfo.device_desc, "WinTV HVR-930C") )
 		{
@@ -1161,7 +1213,7 @@ int GetTunerNum( JNIEnv *env,  char* devName, REFCLSID devClassid, DEVICE_DRV_IN
 						} else
 							devNum++;
 
-						slog((env, "BAD Tuner index :%d dev:%s name:%s loc:%s (%d %d) %s\r\n", devNum, devName, Name, 
+						slog((env, "BDA Tuner index :%d dev:%s name:%s loc:%s (%d %d) %s\r\n", devNum, devName, Name, 
 							devBDAInfo->hardware_loc, devNum, i, skip?"skip":"select" ) );
 						char *p = strstr( Name, "\\\\" );
 						if ( p != NULL && !stricmp( p, devName ) )
@@ -1189,7 +1241,7 @@ int GetTunerNum( JNIEnv *env,  char* devName, REFCLSID devClassid, DEVICE_DRV_IN
 						} else
 							devNum++;
 
-						slog((env, "BAD Tuner index :%d dev:%s name:'%s' id:'%s' (%d %d) %s\r\n", devNum, devName, Name, 
+						slog((env, "BDA Tuner index :%d dev:%s name:'%s' id:'%s' (%d %d) %s\r\n", devNum, devName, Name, 
 							devBDAInfo->hardware_id, devNum, i, skip?"skip":"select" ) );
 						char *p = strstr( Name, "\\\\" );
 						if ( p != NULL && !stricmp( p, devName ) )

--- a/native/dll/DShowCapture-2/DeviceVerify.cpp
+++ b/native/dll/DShowCapture-2/DeviceVerify.cpp
@@ -885,19 +885,15 @@ JNIEXPORT jint JNICALL Java_sage_DShowCaptureDevice_getDeviceCaps0
 			hasCaptureDetails = false;
 			detailsCaptureMask = 0x000800;  // sage_DShowCaptureDevice_MPEG_AV_CAPTURE_MASK
 			detailsChipsetMask = 0;
-			if (strstr(capFiltName, "Hauppauge WinTV 885 Alt TS Capture"))
 			// set up DVB-S on Hauppauge WinTV 885 Alt TS Capture
-			{
-				BDAInputType = sage_DShowCaptureDevice_BDA_DVB_S;
-				slog((env, "An AltBDATunerModel tuner card is found, DVB-S added into source.\r\n"));
-			}
+			if (strstr(capFiltName, "Hauppauge WinTV 885 Alt TS Capture"))
+				AltBDATunerDVBS(BDAInputType, env);
 			else
 			if (strstr(capFiltName, "Hauppauge WinTV 885 TS Capture"))
 			// set up DVB-T on Hauppauge WinTV 885 TS Capture
-			{
-				BDAInputType = sage_DShowCaptureDevice_BDA_DVB_T;
-				slog((env, "A bundle card is found (Analog+DVB-T), DVB-T added into source.\r\n"));
-			}
+				BDATunerDVBT(BDAInputType, env);
+			else
+				slog((env, "BDA tuners are only on TS Capture Devices.\r\n"));
 		}
 		else
 
@@ -910,32 +906,28 @@ JNIEXPORT jint JNICALL Java_sage_DShowCaptureDevice_getDeviceCaps0
 			hasCaptureDetails = false;
 			detailsCaptureMask = 0x000800;  // sage_DShowCaptureDevice_MPEG_AV_CAPTURE_MASK
 			detailsChipsetMask = 0;
-			if (strstr(capFiltName, "Hauppauge WinTV 885 Alt TS Capture"))
 			// set up DVB-S on Hauppauge WinTV 885 Alt TS Capture
-			{
-				BDAInputType = sage_DShowCaptureDevice_BDA_DVB_S;
-				slog((env, "An AltBDATunerModel tuner card is found, DVB-S added into source.\r\n"));
-			}
+			if (strstr(capFiltName, "Hauppauge WinTV 885 Alt TS Capture"))
+				AltBDATunerDVBS(BDAInputType, env);
 			else
 			if (strstr(capFiltName, "Hauppauge WinTV 885 TS Capture"))
 			// set up DVB-T & DVB-C on Hauppauge WinTV 885 TS Capture
-			{
-				BDAInputType = sage_DShowCaptureDevice_BDA_DVB_T | sage_DShowCaptureDevice_BDA_DVB_C;
-				slog((env, "A bundle card is found (Analog+DVB-T+DVB-C), DVB-T|DVB-C added into source.\r\n"));
-			}
+				BDATunerDVBTC(BDAInputType, env);
+			else
+				slog((env, "BDA tuners are only on TS Capture Devices.\r\n"));
 		}
 		else
 
-		// hard code for HVR-2200, 2210 and 2205. desc:"WinTV-HVR-2210", "WinTV-HVR-2200"and "WinTV-HVR-2205"
+		// hard code for HVR-2200 and 2210. desc:"WinTV-HVR-2210" and "WinTV-HVR-2200"
 		// it's a multi-tuner DVB-T but takes takes a long time to initialize as it steps through all the BDA tuners types to find DVB-T
-		if (strstr(CaptureDrvInfo.device_desc, "HVR-2200") || strstr(CaptureDrvInfo.device_desc, "HVR-2210") || strstr(CaptureDrvInfo.device_desc, "HVR-2205"))
+		if (strstr(CaptureDrvInfo.device_desc, "HVR-2200") || strstr(CaptureDrvInfo.device_desc, "HVR-2210"))
 		{
 			isHybridCapture = false;
 			hasCaptureDetails = false;
 			detailsCaptureMask = 0x000800;  // sage_DShowCaptureDevice_MPEG_AV_CAPTURE_MASK
 			detailsChipsetMask = 0;
 			BDAInputType = sage_DShowCaptureDevice_BDA_DVB_T;
-			slog((env, "A multi-tuner card is found (Analog+DVB-T), 2 x DVB-T added into source.\r\n"));
+			slog((env, "A multi-tuner card is found, DVB-T added into source.\r\n"));
 		}
 		else
 
@@ -1169,6 +1161,33 @@ JNIEXPORT jint JNICALL Java_sage_DShowCaptureDevice_getDeviceCaps0
 //	CoUninitialize();
 	slog((env, "DeviceCap: 0x%x\r\n", newCaptureType   ) );
 	return newCaptureType;
+}
+
+void BDATunerDVBT(DWORD &BDAInputType, JNIEnv * &env)
+{
+	{
+		BDAInputType = sage_DShowCaptureDevice_BDA_DVB_T;
+		slog((env, "A bundle tuner card is found, DVB-T added into source.\r\n"));
+	}
+
+}
+
+void BDATunerDVBTC(DWORD &BDAInputType, JNIEnv * &env)
+{
+	{
+		BDAInputType = sage_DShowCaptureDevice_BDA_DVB_T | sage_DShowCaptureDevice_BDA_DVB_C;
+		slog((env, "A bundle tuner card is found, DVB-T|DVB-C added into source.\r\n"));
+	}
+
+}
+
+void AltBDATunerDVBS(DWORD &BDAInputType, JNIEnv * &env)
+{
+	{
+		BDAInputType = sage_DShowCaptureDevice_BDA_DVB_S;
+		slog((env, "An AltBDATunerModel tuner card is found, DVB-S added into source.\r\n"));
+	}
+
 }
 
 int GetTunerNum( JNIEnv *env,  char* devName, REFCLSID devClassid, DEVICE_DRV_INF* devBDAInfo )

--- a/native/dll/DShowCapture-2/DeviceVerify.cpp
+++ b/native/dll/DShowCapture-2/DeviceVerify.cpp
@@ -885,15 +885,21 @@ JNIEXPORT jint JNICALL Java_sage_DShowCaptureDevice_getDeviceCaps0
 			hasCaptureDetails = false;
 			detailsCaptureMask = 0x000800;  // sage_DShowCaptureDevice_MPEG_AV_CAPTURE_MASK
 			detailsChipsetMask = 0;
-			// set up DVB-S on Hauppauge WinTV 885 Alt TS Capture
 			if (strstr(capFiltName, "Hauppauge WinTV 885 Alt TS Capture"))
-				AltBDATunerDVBS(BDAInputType, env);
+			{
+				// set up DVB-S on Hauppauge WinTV 885 Alt TS Capture
+				BDAInputType = sage_DShowCaptureDevice_BDA_DVB_S;
+				slog((env, "An AltBDATunerModel tuner card is found, DVB-S added into Alt TS Capture source.\r\n"));
+			}
 			else
 			if (strstr(capFiltName, "Hauppauge WinTV 885 TS Capture"))
-			// set up DVB-T on Hauppauge WinTV 885 TS Capture
-				BDATunerDVBT(BDAInputType, env);
+			{
+				// set up DVB-T on Hauppauge WinTV 885 TS Capture
+				BDAInputType = sage_DShowCaptureDevice_BDA_DVB_T;
+				slog((env, "A bundle tuner card is found, DVB-T  added into TS Capture source.\r\n"));
+			}
 			else
-				slog((env, "BDA tuners are only on TS Capture Devices.\r\n"));
+				slog((env, "BDA tuners are only on HVR-4400, 3300 and 4405 TS Capture Devices so not doing anything here.\r\n"));
 		}
 		else
 
@@ -906,19 +912,25 @@ JNIEXPORT jint JNICALL Java_sage_DShowCaptureDevice_getDeviceCaps0
 			hasCaptureDetails = false;
 			detailsCaptureMask = 0x000800;  // sage_DShowCaptureDevice_MPEG_AV_CAPTURE_MASK
 			detailsChipsetMask = 0;
-			// set up DVB-S on Hauppauge WinTV 885 Alt TS Capture
 			if (strstr(capFiltName, "Hauppauge WinTV 885 Alt TS Capture"))
-				AltBDATunerDVBS(BDAInputType, env);
+			{
+				// set up DVB-S on Hauppauge WinTV 885 Alt TS Capture
+				BDAInputType = sage_DShowCaptureDevice_BDA_DVB_S;
+				slog((env, "An AltBDATunerModel tuner card is found, DVB-S added into Alt TS Capture source.\r\n"));
+			}
 			else
 			if (strstr(capFiltName, "Hauppauge WinTV 885 TS Capture"))
-			// set up DVB-T & DVB-C on Hauppauge WinTV 885 TS Capture
-				BDATunerDVBTC(BDAInputType, env);
+			{
+				// set up DVB-T & DVB-C on Hauppauge WinTV 885 TS Capture
+				BDAInputType = sage_DShowCaptureDevice_BDA_DVB_T | sage_DShowCaptureDevice_BDA_DVB_C;
+				slog((env, "A bundle tuner card is found, DVB-T|DVB-C  added into TS Capture source.\r\n"));
+			}
 			else
-				slog((env, "BDA tuners are only on TS Capture Devices.\r\n"));
+				slog((env, "BDA tuners are only on HVR-5525, 5500 and 5505 TS Capture Devices so not doing anything here.\r\n"));
 		}
 		else
 
-		// hard code for HVR-2200 and 2210. desc:"WinTV-HVR-2210" and "WinTV-HVR-2200"
+		// hard code for HVR-2200 and 2210. desc:"WinTV-HVR-2210" and "WinTV-HVR-2200"and
 		// it's a multi-tuner DVB-T but takes takes a long time to initialize as it steps through all the BDA tuners types to find DVB-T
 		if (strstr(CaptureDrvInfo.device_desc, "HVR-2200") || strstr(CaptureDrvInfo.device_desc, "HVR-2210"))
 		{
@@ -927,7 +939,7 @@ JNIEXPORT jint JNICALL Java_sage_DShowCaptureDevice_getDeviceCaps0
 			detailsCaptureMask = 0x000800;  // sage_DShowCaptureDevice_MPEG_AV_CAPTURE_MASK
 			detailsChipsetMask = 0;
 			BDAInputType = sage_DShowCaptureDevice_BDA_DVB_T;
-			slog((env, "A multi-tuner card is found, DVB-T added into source.\r\n"));
+			slog((env, "A multi-tuner card is found, DVB-T added into HVR-22x0 source.\r\n"));
 		}
 		else
 
@@ -942,7 +954,7 @@ JNIEXPORT jint JNICALL Java_sage_DShowCaptureDevice_getDeviceCaps0
 //			detailsCaptureMask = 0x000800;  // sage_DShowCaptureDevice_MPEG_AV_CAPTURE_MASK
 //			detailsChipsetMask = 0;
 //			BDAInputType = sage_DShowCaptureDevice_BDA_DVB_T | sage_DShowCaptureDevice_BDA_DVB_C;
-//			slog((env, "A bundle card is found (DVB-T+DVB-C), DVB-T|DVB-C added into source.\r\n"));
+//			slog((env, "A bundle tuner card is found, DVB-T|DVB-C added into source.\r\n"));
 //		}
 //		else
 
@@ -1161,33 +1173,6 @@ JNIEXPORT jint JNICALL Java_sage_DShowCaptureDevice_getDeviceCaps0
 //	CoUninitialize();
 	slog((env, "DeviceCap: 0x%x\r\n", newCaptureType   ) );
 	return newCaptureType;
-}
-
-void BDATunerDVBT(DWORD &BDAInputType, JNIEnv * &env)
-{
-	{
-		BDAInputType = sage_DShowCaptureDevice_BDA_DVB_T;
-		slog((env, "A bundle tuner card is found, DVB-T added into source.\r\n"));
-	}
-
-}
-
-void BDATunerDVBTC(DWORD &BDAInputType, JNIEnv * &env)
-{
-	{
-		BDAInputType = sage_DShowCaptureDevice_BDA_DVB_T | sage_DShowCaptureDevice_BDA_DVB_C;
-		slog((env, "A bundle tuner card is found, DVB-T|DVB-C added into source.\r\n"));
-	}
-
-}
-
-void AltBDATunerDVBS(DWORD &BDAInputType, JNIEnv * &env)
-{
-	{
-		BDAInputType = sage_DShowCaptureDevice_BDA_DVB_S;
-		slog((env, "An AltBDATunerModel tuner card is found, DVB-S added into source.\r\n"));
-	}
-
 }
 
 int GetTunerNum( JNIEnv *env,  char* devName, REFCLSID devClassid, DEVICE_DRV_INF* devBDAInfo )

--- a/native/dll/DShowCapture-2/GraphManager.cpp
+++ b/native/dll/DShowCapture-2/GraphManager.cpp
@@ -612,7 +612,7 @@ JNIEXPORT jintArray JNICALL Java_sage_DShowCaptureDevice_updateColors0
 	{
 		hr = videoProc->Get(VideoProcAmp_Brightness, &val, &pCaps);
 		retColors[0] = ((val-pMin)*255)/(pMax-pMin);
-		slog(( "Get captue brightness: %d hr:0x%x %s-%d\r\n", val, hr, pCapInfo->videoCaptureFilterName, pCapInfo->videoCaptureFilterNum)); 
+		slog(( "Get capture brightness: %d hr:0x%x %s-%d\r\n", val, hr, pCapInfo->videoCaptureFilterName, pCapInfo->videoCaptureFilterNum)); 
 	}
 
 	hr = videoProc->GetRange(VideoProcAmp_Contrast, &pMin, &pMax, &pSteppingDelta, &pDefault, &pCaps);
@@ -630,7 +630,7 @@ JNIEXPORT jintArray JNICALL Java_sage_DShowCaptureDevice_updateColors0
 	{
 		hr = videoProc->Get(VideoProcAmp_Contrast, &val, &pCaps);
 		retColors[1] = ((val-pMin)*255)/(pMax-pMin);
-		//slog(( "Get captue contrast:%d hr:0x%x %s-%d\r\n", val, hr, pCapInfo->videoCaptureFilterName, pCapInfo->videoCaptureFilterNum)); 
+		//slog(( "Get capture contrast:%d hr:0x%x %s-%d\r\n", val, hr, pCapInfo->videoCaptureFilterName, pCapInfo->videoCaptureFilterNum)); 
 	}
 
 	hr = videoProc->GetRange(VideoProcAmp_Hue, &pMin, &pMax, &pSteppingDelta, &pDefault, &pCaps);
@@ -648,7 +648,7 @@ JNIEXPORT jintArray JNICALL Java_sage_DShowCaptureDevice_updateColors0
 	{
 		hr = videoProc->Get(VideoProcAmp_Hue, &val, &pCaps);
 		retColors[2] = ((val-pMin)*255)/(pMax-pMin);
-		//slog(( "Get captue hue:%d hr:0x%x %s-%d\r\n", val, hr, pCapInfo->videoCaptureFilterName, pCapInfo->videoCaptureFilterNum)); 
+		//slog(( "Get capture hue:%d hr:0x%x %s-%d\r\n", val, hr, pCapInfo->videoCaptureFilterName, pCapInfo->videoCaptureFilterNum)); 
 	}
 
 	hr = videoProc->GetRange(VideoProcAmp_Saturation, &pMin, &pMax, &pSteppingDelta, &pDefault, &pCaps);
@@ -666,7 +666,7 @@ JNIEXPORT jintArray JNICALL Java_sage_DShowCaptureDevice_updateColors0
 	{
 		hr = videoProc->Get(VideoProcAmp_Saturation, &val, &pCaps);
 		retColors[3] = ((val-pMin)*255)/(pMax-pMin);
-		//slog(( "Get captue Saturation: %d hr:0x%x%s-%d\r\n", val, hr, pCapInfo->videoCaptureFilterName, pCapInfo->videoCaptureFilterNum)); 
+		//slog(( "Get capture Saturation: %d hr:0x%x%s-%d\r\n", val, hr, pCapInfo->videoCaptureFilterName, pCapInfo->videoCaptureFilterNum)); 
 	}
 
 	hr = videoProc->GetRange(VideoProcAmp_Sharpness, &pMin, &pMax, &pSteppingDelta, &pDefault, &pCaps);
@@ -684,7 +684,7 @@ JNIEXPORT jintArray JNICALL Java_sage_DShowCaptureDevice_updateColors0
 	{
 		hr = videoProc->Get(VideoProcAmp_Sharpness, &val, &pCaps);
 		retColors[4] = ((val-pMin)*255)/(pMax-pMin);
-		//slog(( "Get captue sharpness: %d hr:0x%x %s-%d\r\n", val, hr, pCapInfo->videoCaptureFilterName, pCapInfo->videoCaptureFilterNum)); 
+		//slog(( "Get capture sharpness: %d hr:0x%x %s-%d\r\n", val, hr, pCapInfo->videoCaptureFilterName, pCapInfo->videoCaptureFilterNum)); 
 	}
 
 	SAFE_RELEASE(videoProc);


### PR DESCRIPTION
Each TS capture device now correctly only displays the tuners available on that capture device.   Analog capture still needs work