### PR TITLE
Clean up of VS2015 warnings - Part 4

### DIFF
--- a/native/common/jni-util.cpp
+++ b/native/common/jni-util.cpp
@@ -665,7 +665,7 @@ jboolean GetMapBoolValue(JNIEnv* env, jobject map, const char* optionName, jbool
 	}
 	return JNI_TRUE;
 }
-jboolean GetMapStringValue(JNIEnv* env, jobject map, const char* optionName, char* rv, unsigned long rvlen)
+jboolean GetMapStringValue(JNIEnv* env, jobject map, const char* optionName, char* rv, unsigned long rvlen, unsigned long* rvCount)
 {
 	jstring keyString = env->NewStringUTF(optionName);
 	static jclass mapClass = (jclass) env->NewGlobalRef(env->FindClass("java/util/Map"));

--- a/native/dll/Win32DLL/WindowsServiceControl.cpp
+++ b/native/dll/Win32DLL/WindowsServiceControl.cpp
@@ -685,7 +685,6 @@ GetAccountSid(
             // 
             // reallocate memory
             // 
-
             PSID tmpSid = NULL;
             if ((tmpSid = HeapReAlloc(GetProcessHeap(), 0, *Sid, cbSid)) == NULL)
             {

--- a/native/exe/MiniClientLauncher/MiniClientLauncher.cpp
+++ b/native/exe/MiniClientLauncher/MiniClientLauncher.cpp
@@ -236,7 +236,7 @@ int APIENTRY WinMain(HINSTANCE hInstance,
 
 	// Set the current working directory to be the folder the EXE is in.
 	errno_t err;
-	if ((err = _chdir(appPath)) != 0) // If this returns 0 we have bigger problems
+	if ((err = _chdir(appPath)) != 0) // If this doesn't return 0 we have bigger problems
 	{
 		errorMsg("Could not set the working directory", "Change to working directory failed");
 		return FALSE;

--- a/native/exe/ServiceControlLaunch/ServiceControlLaunch.cpp
+++ b/native/exe/ServiceControlLaunch/ServiceControlLaunch.cpp
@@ -202,7 +202,7 @@ int APIENTRY WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance,
 
 	// Set the current working directory to be the folder the EXE is in.
 	errno_t err;
-	if ((err = _chdir(appPath)) != 0) // If this returns 0 we have bigger problems
+	if ((err = _chdir(appPath)) != 0) // If this doesnt return 0 we have bigger problems
 	{
 		errorMsg("Could not set the working directory", "Change to working directory failed");
 		return FALSE;

--- a/native/include/jni-util.h
+++ b/native/include/jni-util.h
@@ -56,7 +56,7 @@ extern "C" {
 	jboolean GetMapIntValue(JNIEnv* env, jobject map, const char* optionName, jint* rv);
 	jboolean GetMapLongValue(JNIEnv* env, jobject map, const char* optionName, jlong* rv);
 	jboolean GetMapBoolValue(JNIEnv* env, jobject map, const char* optionName, jboolean* rv);
-	jboolean GetMapStringValue(JNIEnv* env, jobject map, const char* optionName, char* rv, unsigned long rvlen);
+	jboolean GetMapStringValue(JNIEnv* env, jobject map, const char* optionName, char* rv, unsigned long rvlen, unsigned long* rvCount);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Changes from SageService Launcher and MiniClient Launcher applied to Launcher
Resolve Compile and Static Analysis warnings
Change to MS safe/secure functions
Reinstate field in GetMapStringValue in jni-util.cpp and jni-util.h
Tidy up indentation in WindowsServiceControl.cpp
Correct comments in MiniClientLauncher.cpp and ServiceControlLaunch.cpp