### PR TITLE
Fix MpegDeMux DWORD alignment causing playback crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Change Log
 
+* Fixed MpegDeMux that crashed some MPEG2 playback (Windows)
 * Change service launcher (Windows) to support local JRE
 * Change watch ignore times from constants to properties
 * Tidy up warnings in VS2015 for data type conversions (Windows)

--- a/native/ax/MpegDeMux-3/CDemuxer.cpp
+++ b/native/ax/MpegDeMux-3/CDemuxer.cpp
@@ -911,7 +911,7 @@ HRESULT CDemuxer::SetMpeg2VideoMediaType(CMediaType *cmt, MPEG_VIDEO *pMpegVideo
     cmt->majortype = MEDIATYPE_Video;
     cmt->subtype = MEDIASUBTYPE_MPEG2_VIDEO;
 
-    int header_padded_length = pMpegVideo->actual_header_length + (4 - (pMpegVideo->actual_header_length % 4)) % 4; // pad length to DWORD boundary
+    int header_padded_length = ALIGN_DWORD(pMpegVideo->actual_header_length);
 
     MPEG2VIDEOINFO *videoInfo = // This macro finds the pointer to the last element in the sedhdr block to determine size
         //(MPEG2VIDEOINFO*)cmt->AllocFormatBuffer(FIELD_OFFSET(MPEG2VIDEOINFO, dwSequenceHeader[pMpegVideo->lActualHeaderLen]));
@@ -1006,7 +1006,7 @@ HRESULT CDemuxer::SetH264VideoMediaType(CMediaType *cmt, H264_VIDEO *pH264Video 
 
 	const DWORD H264FOURCC = 0x34363248; //DWORD('H264');
 
-  int header_padded_length = pH264Video->sps_length + (4 - (pH264Video->sps_length % 4)) % 4; // pad length to DWORD boundary
+  int header_padded_length = ALIGN_DWORD(pH264Video->sps_length);
 
 	//VIDEOINFOHEADER2 *videoInfo = (VIDEOINFOHEADER2*)cmt->AllocFormatBuffer( sizeof(VIDEOINFOHEADER2)+pH264Video->sps_length-4 );
 	 MPEG2VIDEOINFO *videoInfo = // This macro finds the pointer to the last element in the sedhdr block to determine size
@@ -1095,7 +1095,7 @@ HRESULT CDemuxer::SetH264VideoMediaType4Cyberlink(CMediaType *cmt, H264_VIDEO *p
 
 	const DWORD H264FOURCC = 0x34363248; //DWORD('H264');
 
-  int header_padded_length = pH264Video->sps_length + (4 - (pH264Video->sps_length % 4)) % 4; // pad length to DWORD boundary
+  int header_padded_length = ALIGN_DWORD(pH264Video->sps_length);
 
 	//VIDEOINFOHEADER2 *videoInfo = (VIDEOINFOHEADER2*)cmt->AllocFormatBuffer( sizeof(VIDEOINFOHEADER2)+pH264Video->sps_length-4 );
 	 MPEG2VIDEOINFO *videoInfo = // This macro finds the pointer to the last element in the sedhdr block to determine size

--- a/native/ax/MpegDeMux-3/CDemuxer.h
+++ b/native/ax/MpegDeMux-3/CDemuxer.h
@@ -36,6 +36,9 @@
 #define PTS_ROUND_UP( LastPTS, FirstPTS ) ((LastPTS + PTS_OF_3HOUR < FirstPTS &&  FirstPTS + PTS_OF_3HOUR > MAX_PTS_VALUE ) ? LastPTS+MAX_PTS_VALUE : LastPTS ) 
 //#define PTS_ROUND_UP( LastPTS, FirstPTS ) LastPTS
 
+#define ALIGN_DWORD( x ) ( (x)+(4-((x)%4))%4 ); // pad size to DWORD (modulo 4) boundary
+
+
 #define AC3_ENABLE	0x01
 #define EAC3_ENABLE	0x02
 #define TAC3_ENABLE	0x04


### PR DESCRIPTION
This fixes an issue in MpegDeMux.ax

When storing the MPEG2 sequence header into bottom of the MPEG2VIDEOINFO data structure it is defined as an array of type DWORD.  Since the MPEG2 sequence headers are by nature 22, 86 or 150 bytes they are not naturally DWORD aligned.  Some MPEG2 files crash when the downstream filter is trying to connect with these native header sizes.  Padding the header and most critically the cbSequenceHeader member to a modulo 4 value corrects this.

The forum issue is:  https://forums.sagetv.com/forums/showthread.php?t=66336

MPEG2VIDEOINFO  definiton: https://docs.microsoft.com/en-us/previous-versions/ms787321(v%3Dvs.85)

The crash was reproduced on my system and the fix confirmed.