### PR TITLE
Transcoding enhancements no debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 
 ##Next
-* Added ability to used fixed push format when transcoding is required, but not low bandwidth
+* Added ability to use fixed push format when transcoding is required, but not low bandwidth
 * Added 720, 1080 and SOURCE (use video source resolution) options to FFMPEGTranscoder for fixed transcoding
 * Added SOURCE option to FPS that calculates GOP automatically and uses FPS of source videos
 * Added an option for Audio Channels.  Does not allow a value greater than source audio

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+##Next
+* Added ability to used fixed push format when transcoding is required, but not low bandwidth
+* Added 720, 1080 and SOURCE (use video source resolution) options to FFMPEGTranscoder for fixed transcoding
+* Added SOURCE option to FPS that calculates GOP automatically and uses FPS of source videos
+* Added an option for Audio Channels.  Does not allow a value greater than source audio
+
 ## Version 9.2.2 (2020-05-16)
 * Fixed MpegDeMux that crashed some MPEG2 playback (Windows)
 * Change service launcher (Windows) to support local JRE

--- a/java/sage/FFMPEGTranscoder.java
+++ b/java/sage/FFMPEGTranscoder.java
@@ -601,6 +601,7 @@ public class FFMPEGTranscoder implements TranscodeEngine
             else if ("bframes".equals(propName))
               bf = propVal;
             else if ("fps".equals(propName))
+            {
               if("SOURCE".equals(propVal))
               {
                 DecimalFormat twoDForm = new DecimalFormat("#.##");
@@ -609,6 +610,7 @@ public class FFMPEGTranscoder implements TranscodeEngine
               }
               else    
                 r = propVal;
+            }
             else if ("audiosampling".equals(propName))
               ar = propVal;
             else if ("resolution".equals(propName))

--- a/java/sage/FFMPEGTranscoder.java
+++ b/java/sage/FFMPEGTranscoder.java
@@ -15,6 +15,8 @@
  */
 package sage;
 
+import java.text.DecimalFormat;
+
 public class FFMPEGTranscoder implements TranscodeEngine
 {
   private static final boolean XCODE_DEBUG = Sage.DBG && Sage.getBoolean("media_server/transcode_debug", false);
@@ -576,6 +578,12 @@ public class FFMPEGTranscoder implements TranscodeEngine
           {
             if ("videocodec".equals(propName))
               vcodec = propVal;
+            else if ("audiochannels".equals(propName))
+            {
+              //Only set property if the source audio has atleast as many channels as the setting
+              if(Integer.parseInt(propVal) <= sourceFormat.getAudioFormat().getChannels())
+                ac = propVal;
+            }
             else if ("audiocodec".equals(propName))
               acodec = propVal;
             else if ("videobitrate".equals(propName))
@@ -593,7 +601,14 @@ public class FFMPEGTranscoder implements TranscodeEngine
             else if ("bframes".equals(propName))
               bf = propVal;
             else if ("fps".equals(propName))
-              r = propVal;
+              if("SOURCE".equals(propVal))
+              {
+                DecimalFormat twoDForm = new DecimalFormat("#.##");
+                r = twoDForm.format(sourceFormat.getVideoFormat().getFps());
+                g = (Math.round(sourceFormat.getVideoFormat().getFps()) * 10) + "";
+              }
+              else    
+                r = propVal;
             else if ("audiosampling".equals(propName))
               ar = propVal;
             else if ("resolution".equals(propName))
@@ -603,6 +618,12 @@ public class FFMPEGTranscoder implements TranscodeEngine
                 s = MMC.getInstance().isNTSCVideoFormat() ? "720x480" : "720x576";
                 deinterlace = false;
               }
+              else if("720".equals(propVal))
+                s = "1280x720";
+              else if("1080".equals(propVal))
+                s = "1920x1080";
+              else if("SOURCE".equals(propVal))
+                s = inSourceFormat.getVideoFormat().getWidth() + "x" + inSourceFormat.getVideoFormat().getHeight();
               else
                 s = MMC.getInstance().isNTSCVideoFormat() ? "352x240" : "352x288";
             }

--- a/java/sage/MiniPlayer.java
+++ b/java/sage/MiniPlayer.java
@@ -1097,8 +1097,10 @@ public class MiniPlayer implements DVDMediaPlayer
             sage.media.format.ContainerFormat currFileFormat = currMF.getFileFormat();
             if (currFileFormat != null && "true".equals(currFileFormat.getMetadataProperty("VARIED_FORMAT")))
               currFileFormat = sage.media.format.FormatParser.getFileFormat(file);
-            //Check to see if there was a fixed format defined for transcoding
-            if(fixedPushFormat != null && fixedPushFormat.length() > 0)
+            
+            //Check to see if there was a fixed format defined for transcoding and that the file has video
+            if(fixedPushFormat != null && fixedPushFormat.length() > 0 
+                    && currFileFormat != null && currFileFormat.getVideoFormats().length > 0)
             {
                 if (Sage.DBG) System.out.println("Overriding transcode mode because a fixed format was set by client");
                 prefTranscodeMode = fixedPushFormat;

--- a/java/sage/MiniPlayer.java
+++ b/java/sage/MiniPlayer.java
@@ -1100,7 +1100,7 @@ public class MiniPlayer implements DVDMediaPlayer
             //Check to see if there was a fixed format defined for transcoding
             if(fixedPushFormat != null && fixedPushFormat.length() > 0)
             {
-                if (Sage.DBG) System.out.println("\tOverriding transcode mode because a fixed format was set by client");
+                if (Sage.DBG) System.out.println("Overriding transcode mode because a fixed format was set by client");
                 prefTranscodeMode = fixedPushFormat;
             }
             mpegSrc.setStreamTranscodeMode(prefTranscodeMode, currFileFormat);

--- a/java/sage/MiniPlayer.java
+++ b/java/sage/MiniPlayer.java
@@ -1097,6 +1097,12 @@ public class MiniPlayer implements DVDMediaPlayer
             sage.media.format.ContainerFormat currFileFormat = currMF.getFileFormat();
             if (currFileFormat != null && "true".equals(currFileFormat.getMetadataProperty("VARIED_FORMAT")))
               currFileFormat = sage.media.format.FormatParser.getFileFormat(file);
+            //Check to see if there was a fixed format defined for transcoding
+            if(fixedPushFormat != null && fixedPushFormat.length() > 0)
+            {
+                if (Sage.DBG) System.out.println("\tOverriding transcode mode because a fixed format was set by client");
+                prefTranscodeMode = fixedPushFormat;
+            }
             mpegSrc.setStreamTranscodeMode(prefTranscodeMode, currFileFormat);
             transcoded = false;
             serverSideTranscoding = true;

--- a/java/sage/Version.java
+++ b/java/sage/Version.java
@@ -23,7 +23,7 @@ public class Version
 {
   public static final byte MAJOR_VERSION = 9;
   public static final byte MINOR_VERSION = 2;
-  public static final byte MICRO_VERSION = 2;
+  public static final byte MICRO_VERSION = 3;
 
   public static final String VERSION = MAJOR_VERSION + "." + MINOR_VERSION + "." + MICRO_VERSION + "." + SageConstants.BUILD_VERSION;
 


### PR DESCRIPTION
I made some minor changes to the behavior of how SageTV determines when to use fixed transcoding.  I added a number of properties to the fixed transcode section to allow for HD transcoding.  I tried my best to make the changes backwards compatible.  I do not believe they will interfere with any of the other clients.  There are a few users using this, and it appears to be working well.

Josh