### PR TITLE
This will disable FastMuxSwitch if a client is actively transcoding a liveTV stream.

### DIFF
--- a/java/sage/MiniPlayer.java
+++ b/java/sage/MiniPlayer.java
@@ -617,6 +617,20 @@ public class MiniPlayer implements DVDMediaPlayer
     }
   }
 
+  /***
+   * Determines if this instance of the miniplayer is transcoding
+   * @return Returns true if the miniplayer is transcoding 
+   */
+  public boolean isTranscoding()
+  {
+    if(this.mpegSrc.getTranscoder() != null && serverSideTranscoding)
+    {
+      return true;
+    }      
+    
+    return false;
+  }
+  
   public void load(byte majorTypeHint, byte minorTypeHint, String encodingHint, java.io.File file, String hostname, boolean timeshifted, long bufferSize) throws PlaybackException
   {
     VideoFrame vf = VideoFrame.getVideoFrameForPlayer(MiniPlayer.this);

--- a/java/sage/MiniPlayer.java
+++ b/java/sage/MiniPlayer.java
@@ -623,7 +623,7 @@ public class MiniPlayer implements DVDMediaPlayer
    */
   public boolean isTranscoding()
   {
-    if(this.mpegSrc.getTranscoder() != null && serverSideTranscoding)
+    if(mpegSrc != null && mpegSrc.getTranscoder() != null && serverSideTranscoding)
     {
       return true;
     }      

--- a/java/sage/Seeker.java
+++ b/java/sage/Seeker.java
@@ -4174,7 +4174,7 @@ if (encState.currRecord.getDuration() + (Sage.time() - encState.lastResetTime) >
 
             switchThis = fastMuxSwitch && es.capDev.supportsFastMuxSwitch() && es.capDev.getRecordedBytes() > 0 && es.currRecordFile.getSize() > 0;
 
-            if(this.isAClientControllingCaptureDevice(es.capDev) && this.isClientTranscodingMediaFile(es.currRecordFile))
+            if (isAClientControllingCaptureDevice(es.capDev) && isClientTranscodingMediaFile(es.currRecordFile))
             {
               if (Sage.DBG) System.out.println("Disabling FastMuxSwitch because a client is actively transcoding the recording");
               switchThis = false;
@@ -4432,20 +4432,19 @@ if (encState.currRecord.getDuration() + (Sage.time() - encState.lastResetTime) >
         }
 
         if ((es.currRecord != newRecord) && (es.currRecord != null))
-	{
-	  if (Sage.DBG) System.out.println("Change in record, logging recorded data.");
-	  
-	  switchThis = fastMuxSwitch && es.capDev.supportsFastMuxSwitch() && es.capDev.getRecordedBytes() > 0 && es.currRecordFile.getSize() > 0;
-	  
-	  if(this.isAClientControllingCaptureDevice(es.capDev) && this.isClientTranscodingMediaFile(es.currRecordFile))
-	  {
+        {
+          if (Sage.DBG) System.out.println("Change in record, logging recorded data.");
+          switchThis = fastMuxSwitch && es.capDev.supportsFastMuxSwitch() && es.capDev.getRecordedBytes() > 0 && es.currRecordFile.getSize() > 0;
+
+          if(this.isAClientControllingCaptureDevice(es.capDev) && this.isClientTranscodingMediaFile(es.currRecordFile))
+          {
             if (Sage.DBG) System.out.println("Disabling FastMuxSwitch because a client is actively transcoding the recording");
             switchThis = false;
-	  }
-	  
-	  endRecord(es, currTime, switchThis);
-	  switchAny = true;
-	}
+          }
+
+          endRecord(es, currTime, switchThis);
+          switchAny = true;
+        }
 
         if ((es.currRecord != newRecord) && (newRecord != null))
         {

--- a/java/sage/Seeker.java
+++ b/java/sage/Seeker.java
@@ -3240,6 +3240,27 @@ if (encState.currRecord.getDuration() + (Sage.time() - encState.lastResetTime) >
     return null;
   }
 
+  /***
+   * Check to see if any of the clients are actively transcoding the passed
+   * mediafile
+   * @param mf  Mediafile to check to see if it is being transcoded
+   * @return Returns true if a client is actively transcoding the file
+   */
+  private boolean isClientTranscodingMediaFile(MediaFile mf)
+  {
+    Iterator<UIManager> uiWalker = UIManager.getUIIterator();
+      
+    while (uiWalker.hasNext())
+    {
+      if (uiWalker.next().getVideoFrame().isTranscodingMediaFile(mf))
+      {
+        return true;
+      }
+    }
+      
+    return false;
+  }
+  
   private void cleanupPartialsAndUnwanted()
   {
     if (Sage.DBG) System.out.println("Seeker clearing unwanted and partial files...");
@@ -4150,8 +4171,16 @@ if (encState.currRecord.getDuration() + (Sage.time() - encState.lastResetTime) >
           {
             if (Sage.DBG) System.out.println("Current record is over.");
             defaultRecord = null;
-            endRecord(es, currTime, switchThis = fastMuxSwitch && es.capDev.supportsFastMuxSwitch() && es.capDev.getRecordedBytes() > 0 &&
-                es.currRecordFile.getSize() > 0);
+
+            switchThis = fastMuxSwitch && es.capDev.supportsFastMuxSwitch() && es.capDev.getRecordedBytes() > 0 && es.currRecordFile.getSize() > 0;
+
+            if(this.isAClientControllingCaptureDevice(es.capDev) && this.isClientTranscodingMediaFile(es.currRecordFile))
+            {
+              if (Sage.DBG) System.out.println("Disabling FastMuxSwitch because a client is actively transcoding the recording");
+              switchThis = false;
+            }
+
+            endRecord(es, currTime, switchThis);
             switchAny = true;
           }
         }
@@ -4403,12 +4432,20 @@ if (encState.currRecord.getDuration() + (Sage.time() - encState.lastResetTime) >
         }
 
         if ((es.currRecord != newRecord) && (es.currRecord != null))
-        {
-          if (Sage.DBG) System.out.println("Change in record, logging recorded data.");
-          endRecord(es, currTime, switchThis = fastMuxSwitch && es.capDev.supportsFastMuxSwitch() && es.capDev.getRecordedBytes() > 0 &&
-              es.currRecordFile.getSize() > 0);
-          switchAny = true;
-        }
+	{
+	  if (Sage.DBG) System.out.println("Change in record, logging recorded data.");
+	  
+	  switchThis = fastMuxSwitch && es.capDev.supportsFastMuxSwitch() && es.capDev.getRecordedBytes() > 0 && es.currRecordFile.getSize() > 0;
+	  
+	  if(this.isAClientControllingCaptureDevice(es.capDev) && this.isClientTranscodingMediaFile(es.currRecordFile))
+	  {
+            if (Sage.DBG) System.out.println("Disabling FastMuxSwitch because a client is actively transcoding the recording");
+            switchThis = false;
+	  }
+	  
+	  endRecord(es, currTime, switchThis);
+	  switchAny = true;
+	}
 
         if ((es.currRecord != newRecord) && (newRecord != null))
         {

--- a/java/sage/VideoFrame.java
+++ b/java/sage/VideoFrame.java
@@ -4829,6 +4829,25 @@ public final class VideoFrame extends BasicVideoFrame implements Runnable
     return (testInput != null) && testInput.getCaptureDevice().equals(capDev);
   }
 
+  /***
+   * Determine if the client is currently transcoding the mediafile
+   * @param mf The media file object check
+   * @return Returns true if the client is currently transcoding the given mediafile
+   */
+  public boolean isTranscodingMediaFile(MediaFile mf)
+  {    
+    if(player instanceof MiniPlayer)
+    {
+      //((MiniPlayer)player).getFi
+      if(this.getCurrFile() == mf && ((MiniPlayer)player).isTranscoding())
+      {
+        return true;
+      }
+    }
+      
+    return false;
+  }
+  
   // This returns true if there is another operation sitting in the job queue that would terminate
   // the currently processing playback request. This is used to avoid error situations where we are
   // transitioning between pieces of content quickly and one that we are trying to watch may have already

--- a/java/sage/VideoFrame.java
+++ b/java/sage/VideoFrame.java
@@ -4836,10 +4836,9 @@ public final class VideoFrame extends BasicVideoFrame implements Runnable
    */
   public boolean isTranscodingMediaFile(MediaFile mf)
   {    
-    if(player instanceof MiniPlayer)
+    if (player instanceof MiniPlayer)
     {
-      //((MiniPlayer)player).getFi
-      if(this.getCurrFile() == mf && ((MiniPlayer)player).isTranscoding())
+      if (this.getCurrFile() == mf && ((MiniPlayer)player).isTranscoding())
       {
         return true;
       }


### PR DESCRIPTION
It appears that when SageTV is doing server side transcoding that it is not able to do a fastmuxswitch and have the client transition to the new program/timeslot.  I have noticed this behavior in the Placeshifter, and the andriod client.  With this change, placeshifter is able to transition between timeslots without issue.  And when you are using a client without transcoding, it does a fastmuxswitch without issue.