### PR TITLE
Added option to FFMpegTranscoder to be able to copy audio or video without conversion (remux)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## Next ##
+* Added option to FFMPEGTranscoder to allow for a setting to copy video or audio 
+
 ## Version 9.2.5 (2021-05-24)
 * Fixed 32-bit installer incorrectly removing uu_irsage.dll which broke USB-UIRT (Windows)
 * Visual Studio launcher project cleanup (Windows)

--- a/java/sage/FFMPEGTranscoder.java
+++ b/java/sage/FFMPEGTranscoder.java
@@ -644,7 +644,7 @@ public class FFMPEGTranscoder implements TranscodeEngine
         }
         else
         {
-          xcodeParams += " -vcodec " + vcodec + " -s " + s + " -ac " + ac + " -g " + g + " -bf " + bf + (deinterlace ? " -deinterlace " : "");
+          xcodeParams += " -vcodec " + vcodec  + " -b " + b + " -r " + r + " -s " + s  + " -g " + g + " -bf " + bf + (deinterlace ? " -deinterlace " : "");
         }
         
         if(acodec.equals("COPY"))
@@ -653,7 +653,7 @@ public class FFMPEGTranscoder implements TranscodeEngine
         }
         else
         {
-          xcodeParams += " -acodec " + acodec + " -r " + r + " -b " + b + " -ar " + ar + " -ab " + ab;
+          xcodeParams += " -acodec " + acodec + " -ab " + ab + " -ar " + ar  + " -ac " + ac;
         }
         
         xcodeParams += " -packetsize " + packetsize;

--- a/java/sage/FFMPEGTranscoder.java
+++ b/java/sage/FFMPEGTranscoder.java
@@ -635,9 +635,29 @@ public class FFMPEGTranscoder implements TranscodeEngine
           catch (NumberFormatException e)
           {}
         }
-
-        xcodeParams = "-f " + f + " -vcodec " + vcodec + " -s " + s + " -ac " + ac + " -g " + g + " -bf " + bf + (deinterlace ? " -deinterlace " : "") +
-            " -acodec " + acodec + " -r " + r + " -b " + b + " -ar " + ar + " -ab " + ab + " -packetsize " + packetsize;
+        
+        xcodeParams = "-f " + f;
+        
+        if(vcodec.equals("COPY"))
+        {
+          xcodeParams += " -vcodec copy";
+        }
+        else
+        {
+          xcodeParams += " -vcodec " + vcodec + " -s " + s + " -ac " + ac + " -g " + g + " -bf " + bf + (deinterlace ? " -deinterlace " : "");
+        }
+        
+        if(acodec.equals("COPY"))
+        {
+          xcodeParams += " -acodec copy";
+        }
+        else
+        {
+          xcodeParams += " -acodec " + acodec + " -r " + r + " -b " + b + " -ar " + ar + " -ab " + ab;
+        }
+        
+        xcodeParams += " -packetsize " + packetsize;
+        
       }
       dynamicRateAdjust = false;
     }


### PR DESCRIPTION
This is the first of a few changes to allow for remuxing when the container format is not supported using the miniclient.  I am going to add a property for a fixed remux format.

Let me know if you have any questions or concerns.  High level testing has looked good.  Submitting in smaller pieces.