### PR TITLE
Added some additional constraints on -aspect swith in FFMPEGTranscode…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Change Log
 
 ## Next ##
-* Added option to FFMPEGTranscoder to allow for a setting to copy video or audio 
+* Added option to FFMPEGTranscoder to allow for a setting to copy video or audio
+* Added a new option to the Miniclient for fixed remux profile.  This is used when the audio/video codec are supported, but the container is not
+* Added some additional constraints on -aspect swith in FFMPEGTranscoder to make sure an invalid aspect ratio is not passed to the transcoder
 
 ## Version 9.2.5 (2021-05-24)
 * Fixed 32-bit installer incorrectly removing uu_irsage.dll which broke USB-UIRT (Windows)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Next ##
 * Added option to FFMPEGTranscoder to allow for a setting to copy video or audio
 * Added a new option to the Miniclient for fixed remux profile.  This is used when the audio/video codec are supported, but the container is not
-* Added some additional constraints on -aspect swith in FFMPEGTranscoder to make sure an invalid aspect ratio is not passed to the transcoder
+* Added some additional constraints on -aspect switch in FFMPEGTranscoder to make sure an invalid aspect ratio is not passed to the transcoder
 
 ## Version 9.2.5 (2021-05-24)
 * Fixed 32-bit installer incorrectly removing uu_irsage.dll which broke USB-UIRT (Windows)

--- a/java/sage/FFMPEGTranscoder.java
+++ b/java/sage/FFMPEGTranscoder.java
@@ -916,7 +916,7 @@ public class FFMPEGTranscoder implements TranscodeEngine
       if (sourceFormat != null)
       {
         sage.media.format.VideoFormat vidForm = sourceFormat.getVideoFormat();
-        if (vidForm != null)
+        if (vidForm != null && ((vidForm.getArNum() > 0 && vidForm.getArDen() > 0) || (vidForm.getWidth() > 0 && vidForm.getHeight() > 0)))
         {
           xcodeParamsVec.add("-aspect");
           if (vidForm.getArNum() > 0 && vidForm.getArDen() > 0)
@@ -1012,7 +1012,7 @@ public class FFMPEGTranscoder implements TranscodeEngine
       if (sourceFormat != null)
       {
         sage.media.format.VideoFormat vidForm = sourceFormat.getVideoFormat();
-        if (vidForm != null)
+        if (vidForm != null && ((vidForm.getArNum() > 0 && vidForm.getArDen() > 0) || (vidForm.getWidth() > 0 && vidForm.getHeight() > 0)))
         {
           xcodeParamsVec.add("-aspect");
           if (vidForm.getArNum() > 0 && vidForm.getArDen() > 0)
@@ -1110,7 +1110,7 @@ public class FFMPEGTranscoder implements TranscodeEngine
       {
         // Preserve aspect ratio properly
         sage.media.format.VideoFormat vidForm = sourceFormat.getVideoFormat();
-        if (vidForm != null)
+        if (vidForm != null && ((vidForm.getArNum() > 0 && vidForm.getArDen() > 0) || (vidForm.getWidth() > 0 && vidForm.getHeight() > 0)))
         {
           xcodeParamsVec.add("-aspect");
           if (vidForm.getArNum() > 0 && vidForm.getArDen() > 0)


### PR DESCRIPTION
Added some additional constraints on -aspect swith in FFMPEGTranscoder to make sure an invalid aspect ratio is not passed to the transcoder.  In my testing, I saw a few occurrences when watching live TV where the content did not seem to be properly identified, and the container format had no aspect or dimensions to the video.  This caused FFMPEGTranscoder to pass -aspect 0:0.  This caused the transcoder to fail and Sage client to display a blank screen.

I realize this is a code path that should probably not occur, but I also think it is a reasonable check and restriction.  I would rather FFmpeg try again to determine the aspect when it has more data.

Josh