### PR TITLE
Weather updated in STV to now use OpenWeatherMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## Next ##
+* Updated weather in STV to use OpenWeatherMap
 * Added option to FFMPEGTranscoder to allow for a setting to copy video or audio
 * Added a new option to the Miniclient for fixed remux profile.  This is used when the audio/video codec are supported, but the container is not
 * Added some additional constraints on -aspect switch in FFMPEGTranscoder to make sure an invalid aspect ratio is not passed to the transcoder


### PR DESCRIPTION
Updated the STV to use an updated version of the GoogleWeather.jar file (3.x).  It will still work with or without that jar as with previous STVs.  The new GoogleWeather plugin is completed and will be pushed soon as well.