### PR TITLE
Revert PR#461 for Windows build

### DIFF
--- a/installer/wix/SageTVSetup/SageTVVersionInclude.wxi
+++ b/installer/wix/SageTVSetup/SageTVVersionInclude.wxi
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--  Created by InstallerBuild.ps1 script 24-May-2021 16:12 -->
+<!--  Created by InstallerBuild.ps1 script 28-Sep-2021 21:25 -->
 <Include>
   <?define MajorVersion="9" ?>
   <?define MinorVersion="2" ?>

--- a/native/ax/Channel-2/Channel.h
+++ b/native/ax/Channel-2/Channel.h
@@ -54,8 +54,18 @@
 
 #define MAX_SATELLATE_NUM  6
 
-//data structure byte packing throughout
 #ifdef WIN32
+#ifndef bool
+#define bool int
+#endif
+#ifndef false
+#define false 0
+#endif
+#ifndef true
+#define true 1
+#endif
+
+//data structure byte packing throughout
 #include <pshpack1.h>
 #endif
 

--- a/native/include/version.h
+++ b/native/include/version.h
@@ -1,4 +1,4 @@
-/* Created by InstallerBuild.ps1 script 24-May-2021 16:12 */
+/* Created by InstallerBuild.ps1 script 28-Sep-2021 21:25 */
 #define STRINGIZE2(s) #s
 #define STRINGIZE(s) STRINGIZE2(s)
 


### PR DESCRIPTION
bool, true and false are not part of WIN32 natively.  This reverts https://github.com/google/sagetv/pull/461 but only for Windows compiling.