### PR TITLE
Add DirecTVtuner DLL for http tuning.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change Log
 
+* Added DirecTVTuner DLL for http tuning (Windows)
+
 ## Version 9.2.6 (2021-09-13)
 * Updated weather in STV to use OpenWeatherMap
 * Added option to FFMPEGTranscoder to allow for a setting to copy video or audio

--- a/installer/wix/SageTVSetup/Product.wxs
+++ b/installer/wix/SageTVSetup/Product.wxs
@@ -326,6 +326,9 @@
       <Component Id="cmp64245AAB05194798872CE52163814445" Guid="{811ACA52-E790-421a-B206-F395471100B1}">
         <File Id="filC80342EABF304526B4B9E39563D32745" KeyPath="yes" Source="$(var.SourceNative)EXEMultiTunerPlugin.dll" />
       </Component>
+      <Component Id="cmpE532319C89724AFDA2132414C2557DF5" Guid="{D3E02EA7-322B-4C29-9AB4-0CE03CE045A1}">
+        <File Id="fil8709DE86D7624B3CA2FBD71FB9475497" KeyPath="yes" Source="$(var.SourceNative)DirecTVTuner.dll" />
+      </Component>
       <Component Id="cmp975E730BBA4A42adB896A4E616DDD977" Guid="{E301FFF7-55AF-48d6-A615-12ACD1CCA30C}">
         <File Id="fil975E730BBA4A42adB896A4E616DDD977" KeyPath="yes" Source="$(var.SourceNative)HCWIRBlaster.dll" />
       </Component>

--- a/native/SageWorkspace.sln
+++ b/native/SageWorkspace.sln
@@ -108,6 +108,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "HCWIRBlaster", "dll\TunerSt
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "HCWIRBlasterCOM", "exe\HCWIRBlasterCom\HCWIRBlasterCOM.vcxproj", "{8A1B9ADA-9CCA-40DC-AB8D-B6BE4E9E3515}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "DirectTVTuner", "dll\TunerStub\DirectTVTuner.vcxproj", "{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Client Debug|Win32 = Client Debug|Win32
@@ -1742,6 +1744,58 @@ Global
 		{8A1B9ADA-9CCA-40DC-AB8D-B6BE4E9E3515}.Studio Release|Win32.Build.0 = Release|Win32
 		{8A1B9ADA-9CCA-40DC-AB8D-B6BE4E9E3515}.Studio Release|x64.ActiveCfg = Release|x64
 		{8A1B9ADA-9CCA-40DC-AB8D-B6BE4E9E3515}.Studio Release|x64.Build.0 = Release|x64
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Client Debug|Win32.ActiveCfg = Debug|Win32
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Client Debug|Win32.Build.0 = Debug|Win32
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Client Debug|x64.ActiveCfg = Debug|x64
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Client Debug|x64.Build.0 = Debug|x64
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Client Release|Win32.ActiveCfg = Release|Win32
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Client Release|Win32.Build.0 = Release|Win32
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Client Release|x64.ActiveCfg = Release|x64
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Client Release|x64.Build.0 = Release|x64
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Debug_MBCS|Win32.ActiveCfg = Debug|Win32
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Debug_MBCS|Win32.Build.0 = Debug|Win32
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Debug_MBCS|x64.ActiveCfg = Debug|x64
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Debug_MBCS|x64.Build.0 = Debug|x64
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Debug|Win32.ActiveCfg = Debug|Win32
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Debug|Win32.Build.0 = Debug|Win32
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Debug|x64.ActiveCfg = Debug|x64
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Debug|x64.Build.0 = Debug|x64
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Java Client Debug|Win32.ActiveCfg = Debug|Win32
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Java Client Debug|Win32.Build.0 = Debug|Win32
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Java Client Debug|x64.ActiveCfg = Debug|x64
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Java Client Debug|x64.Build.0 = Debug|x64
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Java Debug|Win32.ActiveCfg = Debug|Win32
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Java Debug|Win32.Build.0 = Debug|Win32
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Java Debug|x64.ActiveCfg = Debug|x64
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Java Debug|x64.Build.0 = Debug|x64
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Recorder Debug|Win32.ActiveCfg = Debug|Win32
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Recorder Debug|Win32.Build.0 = Debug|Win32
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Recorder Debug|x64.ActiveCfg = Debug|x64
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Recorder Debug|x64.Build.0 = Debug|x64
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Recorder Release|Win32.ActiveCfg = Release|Win32
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Recorder Release|Win32.Build.0 = Release|Win32
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Recorder Release|x64.ActiveCfg = Release|x64
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Recorder Release|x64.Build.0 = Release|x64
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Release_MBCS|Win32.ActiveCfg = Release|Win32
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Release_MBCS|Win32.Build.0 = Release|Win32
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Release_MBCS|x64.ActiveCfg = Release|x64
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Release_MBCS|x64.Build.0 = Release|x64
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Release|Win32.ActiveCfg = Release|Win32
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Release|Win32.Build.0 = Release|Win32
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Release|x64.ActiveCfg = Release|x64
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Release|x64.Build.0 = Release|x64
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Service Debug|Win32.ActiveCfg = Debug|Win32
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Service Debug|Win32.Build.0 = Debug|Win32
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Service Debug|x64.ActiveCfg = Debug|x64
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Service Debug|x64.Build.0 = Debug|x64
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Service Release|Win32.ActiveCfg = Release|Win32
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Service Release|Win32.Build.0 = Release|Win32
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Service Release|x64.ActiveCfg = Release|x64
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Service Release|x64.Build.0 = Release|x64
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Studio Release|Win32.ActiveCfg = Release|Win32
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Studio Release|Win32.Build.0 = Release|Win32
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Studio Release|x64.ActiveCfg = Release|x64
+		{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}.Studio Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/native/dll/TunerStub/DirectTVTuner.vcxproj
+++ b/native/dll/TunerStub/DirectTVTuner.vcxproj
@@ -1,0 +1,281 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{7916A95F-2F9D-4AF6-BD00-6BD06BCDD531}</ProjectGuid>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <ProjectName>DirecTVTuner</ProjectName>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v140_xp</PlatformToolset>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v140_xp</PlatformToolset>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v140_xp</PlatformToolset>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v140_xp</PlatformToolset>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>12.0.30501.0</_ProjectFileVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <OutDir>$(SolutionDir)Build\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\$(TargetName)\</IntDir>
+    <LinkIncremental>false</LinkIncremental>
+    <TargetName>DirecTVTuner</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <TargetName>DirecTVTuner</TargetName>
+    <OutDir>$(SolutionDir)Build\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\$(TargetName)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <OutDir>$(SolutionDir)Build\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\$(TargetName)\</IntDir>
+    <LinkIncremental>false</LinkIncremental>
+    <TargetName>DirecTVTuner</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <TargetName>DirecTVTuner</TargetName>
+    <OutDir>$(SolutionDir)Build\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\$(TargetName)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Midl>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MkTypLibCompatible>true</MkTypLibCompatible>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <TargetEnvironment>Win32</TargetEnvironment>
+      <TypeLibraryName>$(IntDir)DirecTVTuner.tlb</TypeLibraryName>
+      <HeaderFileName />
+    </Midl>
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>DIRECTV_TUNER;WIN32;_DEBUG;_WINDOWS;_USRDLL;TUNERSTUBDLL_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>$(IntDir)$(TargetName).pch</PrecompiledHeaderOutputFile>
+      <AssemblerListingLocation>$(IntDir)</AssemblerListingLocation>
+      <ObjectFileName>$(IntDir)</ObjectFileName>
+      <ProgramDataBaseFileName>$(IntDir)$(TargetName).pdb</ProgramDataBaseFileName>
+      <WarningLevel>Level3</WarningLevel>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <AdditionalIncludeDirectories>
+      </AdditionalIncludeDirectories>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0409</Culture>
+    </ResourceCompile>
+    <Link>
+      <AdditionalDependencies>winhttp.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ProgramDatabaseFile>$(IntDir)$(ProjectName).pdb</ProgramDatabaseFile>
+      <ImportLibrary>$(IntDir)$(TargetName).lib</ImportLibrary>
+      <TargetMachine>MachineX86</TargetMachine>
+      <SubSystem>Windows</SubSystem>
+      <DelayLoadDLLs>
+      </DelayLoadDLLs>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Midl>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MkTypLibCompatible>true</MkTypLibCompatible>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <TypeLibraryName>$(IntDir)DirectTVTuner.tlb</TypeLibraryName>
+      <HeaderFileName>
+      </HeaderFileName>
+    </Midl>
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>DIRECTV_TUNER;WIN32;_DEBUG;_WINDOWS;_USRDLL;TUNERSTUBDLL_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>$(IntDir)$(TargetName).pch</PrecompiledHeaderOutputFile>
+      <AssemblerListingLocation>$(IntDir)</AssemblerListingLocation>
+      <ObjectFileName>$(IntDir)</ObjectFileName>
+      <ProgramDataBaseFileName>$(IntDir)$(TargetName).pdb</ProgramDataBaseFileName>
+      <WarningLevel>Level3</WarningLevel>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <AdditionalIncludeDirectories>..\..\include;</AdditionalIncludeDirectories>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0409</Culture>
+    </ResourceCompile>
+    <Link>
+      <AdditionalDependencies>winhttp.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ProgramDatabaseFile>$(IntDir)$(ProjectName).pdb</ProgramDatabaseFile>
+      <ImportLibrary>$(IntDir)$(TargetName).lib</ImportLibrary>
+      <SubSystem>Windows</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Midl>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MkTypLibCompatible>true</MkTypLibCompatible>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <TargetEnvironment>Win32</TargetEnvironment>
+      <TypeLibraryName>$(IntDir)DirectTVTuner.tlb</TypeLibraryName>
+      <HeaderFileName />
+    </Midl>
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
+      <PreprocessorDefinitions>DIRECTV_TUNER;WIN32;NDEBUG;_WINDOWS;_USRDLL;TUNERSTUBDLL_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <StringPooling>true</StringPooling>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>$(IntDir)$(TargetName).pch</PrecompiledHeaderOutputFile>
+      <AssemblerListingLocation>$(IntDir)</AssemblerListingLocation>
+      <ObjectFileName>$(IntDir)</ObjectFileName>
+      <ProgramDataBaseFileName>$(IntDir)$(TargetName).pdb</ProgramDataBaseFileName>
+      <WarningLevel>Level3</WarningLevel>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <AdditionalIncludeDirectories>
+      </AdditionalIncludeDirectories>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0409</Culture>
+    </ResourceCompile>
+    <Link>
+      <AdditionalDependencies>winhttp.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <ProgramDatabaseFile>$(IntDir)$(ProjectName).pdb</ProgramDatabaseFile>
+      <ImportLibrary>$(IntDir)$(TargetName).lib</ImportLibrary>
+      <TargetMachine>MachineX86</TargetMachine>
+      <SubSystem>Windows</SubSystem>
+      <DelayLoadDLLs>
+      </DelayLoadDLLs>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Midl>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MkTypLibCompatible>true</MkTypLibCompatible>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <TypeLibraryName>$(IntDir)DirectTVTuner.tlb</TypeLibraryName>
+      <HeaderFileName>
+      </HeaderFileName>
+    </Midl>
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
+      <PreprocessorDefinitions>DIRECTV_TUNER;WIN32;NDEBUG;_WINDOWS;_USRDLL;TUNERSTUBDLL_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <StringPooling>true</StringPooling>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>$(IntDir)$(TargetName).pch</PrecompiledHeaderOutputFile>
+      <AssemblerListingLocation>$(IntDir)</AssemblerListingLocation>
+      <ObjectFileName>$(IntDir)</ObjectFileName>
+      <ProgramDataBaseFileName>$(IntDir)$(TargetName).pdb</ProgramDataBaseFileName>
+      <WarningLevel>Level3</WarningLevel>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <AdditionalIncludeDirectories>..\..\include</AdditionalIncludeDirectories>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0409</Culture>
+    </ResourceCompile>
+    <Link>
+      <AdditionalDependencies>winhttp.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <ProgramDatabaseFile>$(IntDir)$(ProjectName).pdb</ProgramDatabaseFile>
+      <ImportLibrary>$(IntDir)$(TargetName).lib</ImportLibrary>
+      <SubSystem>Windows</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="StdAfx.cpp">
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Disabled</Optimization>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Disabled</Optimization>
+      <BasicRuntimeChecks Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">EnableFastChecks</BasicRuntimeChecks>
+      <BasicRuntimeChecks Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">EnableFastChecks</BasicRuntimeChecks>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">MaxSpeed</Optimization>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|x64'">MaxSpeed</Optimization>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="TunerStubDLL.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="StdAfx.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>


### PR DESCRIPTION
Adding a tuning DLL for DirecTV http tuning.  Confirmed working by a user here:  https://forums.sagetv.com/forums/showthread.php?p=631452&postcount=3  The 32-bit or 64-bit version will be included in the appropriate Windows installers for the next release.