### PR TITLE
Update build process to support ubuntu 18.04 as it is still under support [ci release]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   build:
 
 #    runs-on: ubuntu-latest
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.travis.yml.old
+++ b/.travis.yml.old
@@ -1,3 +1,4 @@
+# No longer in use.  Moved to Github actions
 language: java
 dist: xenial 
 

--- a/.travis.yml.old
+++ b/.travis.yml.old
@@ -1,4 +1,4 @@
-# No longer in use.  Moved to Github actions
+# No longer in use.  Moved to Github actions 09/2021
 language: java
 dist: xenial 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Version 9.2.8 (2022-01-05)
+* Update to build process to support Linux build on Ubuntu 18.04 and JDK 11
+* removed Travis process as no longer used for builds
+
 ## Version 9.2.7 (2022-01-04)
 * Update to build process to support build on JDK 11 while supporting Java 8 dockers to run SageTV
 * Added DirecTVTuner DLL for http tuning (Windows)

--- a/java/sage/Version.java
+++ b/java/sage/Version.java
@@ -23,7 +23,7 @@ public class Version
 {
   public static final byte MAJOR_VERSION = 9;
   public static final byte MINOR_VERSION = 2;
-  public static final byte MICRO_VERSION = 7;
+  public static final byte MICRO_VERSION = 8;
 
   public static final String VERSION = MAJOR_VERSION + "." + MINOR_VERSION + "." + MICRO_VERSION + "." + SageConstants.BUILD_VERSION;
 


### PR DESCRIPTION
As the ubuntu 20.04 build forces glibc to be 2.28 the linux SageTV build would not run on Ubuntu 18.04 which is still under support until mid 2023.  Given that 18.04 may still be used by users for awhile I updated the build process to use Ubuntu 18.04 which allows SageTV build to run on either 18.04 and 20.04 (and their equivalents) .
I also renamed the travis.yml so it would quit running and failing on forked repos