### PR TITLE
* Fix Subtitles on Extender only using 1st subtitle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## Next
+* Fix Subtitles on Extender only using 1st subtitle irrespective of which subtitle is selected
 * Updated gradle script so that project could build in Netbeans
 * Updated the FFMPEGTranscoder to fallback to frame count instead of time to calculate progress
 

--- a/java/sage/MiniPlayer.java
+++ b/java/sage/MiniPlayer.java
@@ -2575,6 +2575,7 @@ public class MiniPlayer implements DVDMediaPlayer
                   target = Integer.parseInt(tag, 16);
                 else
                   target = (Integer.parseInt(tag, 16) << 8);
+                if (Sage.DBG) System.out.println("Subtitle Toggle tag.length" + target); // Only uses subtitle 0 without this for some reason
               }
               catch (NumberFormatException nfe)
               {
@@ -2587,6 +2588,7 @@ public class MiniPlayer implements DVDMediaPlayer
               {
                 target = (Integer.parseInt(tag.substring(0, dashIdx), 16) << 8) |
                     Integer.parseInt(tag.substring(dashIdx + 1, dashIdx + 3), 16);
+                if (Sage.DBG) System.out.println("Subtitle Toggle dashIdx " + target); // Only uses subtitle 0 without this for some reason
               }
               catch (NumberFormatException nfe)
               {
@@ -2629,6 +2631,7 @@ public class MiniPlayer implements DVDMediaPlayer
                   target = Integer.parseInt(tag, 16);
                 else
                   target = (Integer.parseInt(tag, 16) << 8);
+                if (Sage.DBG) System.out.println("Subtitle Change tag.length " + target); // Only uses subtitle 0 without this for some reason
               }
               catch (NumberFormatException nfe)
               {
@@ -2641,6 +2644,7 @@ public class MiniPlayer implements DVDMediaPlayer
               {
                 target = (Integer.parseInt(tag.substring(0, dashIdx), 16) << 8) |
                     Integer.parseInt(tag.substring(dashIdx + 1, dashIdx + 3), 16);
+                if (Sage.DBG) System.out.println("Subtitle Change dashIdx " + target); // Only uses subtitle 0 without this for some reason
               }
               catch (NumberFormatException nfe)
               {

--- a/java/sage/VideoFrame.java
+++ b/java/sage/VideoFrame.java
@@ -5682,7 +5682,7 @@ public final class VideoFrame extends BasicVideoFrame implements Runnable
     String defaultAudioLang = uiMgr.get("default_audio_language", "English"); 
     String defaultLang = uiMgr.get("default_subpic_language", "");
     
-    //Check for forced subtitles if there is not a defaul subtitle language set
+    //Check for forced subtitles if there is not a default subtitle language set
     if(defaultLang == null || defaultLang.length() == 0)
     {
       String [] subs = getDVDAvailableSubpictures();


### PR DESCRIPTION
On extenders irrespective of the subtitle selected, the extender will only ever play the 1st subtitle.

Logs show
Subtitle change is done; subtitle is: # 3 eng
Enabling subpicture stream 0

Added some debug to identify where the disconnect was and the issue resolved. Removing the debug and the issue returns