### PR TITLE
Placeshifter for windows fixes [ci release]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next
 
+## Version 9.2.13 (2025-05-23)
+* More fixes for placeshifter on windows (added consolewin registry optional logging to match client)
+
 ## Version 9.2.12 (2025-05-18)
 * Fix for placeshifter on windows (also added optional logging)
 

--- a/java/sage/Version.java
+++ b/java/sage/Version.java
@@ -23,7 +23,7 @@ public class Version
 {
   public static final byte MAJOR_VERSION = 9;
   public static final byte MINOR_VERSION = 2;
-  public static final byte MICRO_VERSION = 12;
+  public static final byte MICRO_VERSION = 13;
 
   public static final String VERSION = MAJOR_VERSION + "." + MINOR_VERSION + "." + MICRO_VERSION + "." + SageConstants.BUILD_VERSION;
 

--- a/java/sage/media/image/RawImage.java
+++ b/java/sage/media/image/RawImage.java
@@ -15,6 +15,8 @@
  */
 package sage.media.image;
 
+import java.nio.Buffer;
+
 /**
  *
  * @author Narflex
@@ -86,9 +88,9 @@ public class RawImage
   // For multithreading we need to give each caller a new buffer object to handle the positions; but share the same data
   public java.nio.ByteBuffer getROData()
   {
-    dataBuff.mark(); // GCJ needs this or it throws an exception
+    ((Buffer) dataBuff).mark(); // GCJ needs this or it throws an exception
     java.nio.ByteBuffer rv = dataBuff.asReadOnlyBuffer();
-    rv.rewind();
+    ((Buffer) rv).rewind();
     return rv;
   }
 

--- a/java/sage/miniclient/MiniClient.java
+++ b/java/sage/miniclient/MiniClient.java
@@ -15,11 +15,6 @@
  */
 package sage.miniclient;
 
-import java.io.BufferedOutputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.PrintStream;
-
 public class MiniClient
 {
   public static boolean WINDOWS_OS = false;
@@ -29,7 +24,6 @@ public class MiniClient
   public static boolean fsStartup = false;
   public static Integer irKillCode = null;
   public static final String BYTE_CHARSET = "ISO8859_1";
-  public static final String redirectLogProp = "write_output_to_miniClient_log";
   static
   {
     System.out.println("Starting MiniClient");
@@ -166,18 +160,7 @@ public class MiniClient
       }
     };
 
-    if (myProperties.getProperty(redirectLogProp, "false").equalsIgnoreCase("true")){
-        try {
-            PrintStream printStream = new PrintStream(new BufferedOutputStream(new FileOutputStream(redirectLog)),true);
-            System.setOut(printStream);
-            System.setErr(printStream);
-        } catch (FileNotFoundException ex) {
-            ex.printStackTrace();
-        }
-    }else{
-        System.setOut(redir);
-    }
-
+    System.setOut(redir);
     mainArgs = args;
     boolean noretries = false;
     for (int i = 0; args != null && i < args.length; i++)

--- a/native/exe/MiniClientLauncher/MiniClientLauncher.cpp
+++ b/native/exe/MiniClientLauncher/MiniClientLauncher.cpp
@@ -137,14 +137,27 @@ int APIENTRY WinMain(HINSTANCE hInstance,
 							(LPSTR)NULL		);
 
 	/*
-	 * Explicitly load jvm.dll by using the Windows Registry to locate the current version to use.
-	 */
+	* Optionally open a console window for debugging - dependent on "consolewin" in registry
+	*/
 	HKEY rootKey = HKEY_LOCAL_MACHINE;
-	char currVer[16];
 	HKEY myKey;
 	DWORD readType;
 	DWORD dwRead = 0;
 	DWORD hsize = sizeof(dwRead);
+	if (RegOpenKeyEx(rootKey, "Software\\Frey Technologies\\Common", 0, KEY_QUERY_VALUE, &myKey) == ERROR_SUCCESS)
+        {
+                if (RegQueryValueEx(myKey, "consolewin", 0, &readType, (LPBYTE)&dwRead, &hsize) == ERROR_SUCCESS)
+                {
+                        if (dwRead)
+                                AllocConsole();
+                }
+                RegCloseKey(myKey);
+        }
+
+	/*
+	 * Explicitly load jvm.dll by using the Windows Registry to locate the current version to use.
+	 */
+	char currVer[16];
 	hsize = sizeof(currVer);
 	HMODULE exeMod = GetModuleHandle(NULL);
 	LPTSTR appPath = new TCHAR[512];


### PR DESCRIPTION
There were 2 more methods that needed casting (.mark and .rewind)

I also corrected an issue in my windows build that resolved the consolewin issue so the placeshifter launcher now matches the client to use the registry to optionally launch and log to a console window.  I therefore removed the file logging I had added in the .12 release.