### PR TITLE
Security: Add authentication to MediaServer and re-enable DoS protection

### DIFF
--- a/java/sage/MediaServer.java
+++ b/java/sage/MediaServer.java
@@ -354,10 +354,10 @@ public class MediaServer implements Runnable
           commBufRead.flip();
         }
         currByte = (commBufRead.get() & 0xFF);
-        //			if (readTillPanic-- < 0)
-        //			{
-        //				throw new java.io.IOException("TOO MANY BYTES RECIEVED FOR A LINE, BAILING TO PREVENT DOS ATTACK");
-        //			}
+        if (readTillPanic-- < 0)
+        {
+          throw new java.io.IOException("TOO MANY BYTES RECIEVED FOR A LINE, BAILING TO PREVENT DOS ATTACK");
+        }
       }
     }
 
@@ -1000,6 +1000,22 @@ public class MediaServer implements Runnable
         }
         commBufRead = java.nio.ByteBuffer.allocate(4096);
         commBufWrite = java.nio.ByteBuffer.allocate(4096);
+        // Shared-secret authentication check
+        String authKey = Sage.get("media_server_auth_key", "");
+        if (authKey.length() > 0)
+        {
+          StringBuffer authLine = readLineBytes();
+          if (authLine == null || !authKey.equals(authLine.toString()))
+          {
+            if (MEDIA_SERVER_DEBUG) System.out.println("MediaServer auth failed, closing connection");
+            try { s.close(); } catch (Exception e) {}
+            return;
+          }
+          commBufWrite.clear();
+          commBufWrite.put(OK_BYTES).flip();
+          s.write(commBufWrite);
+          if (MEDIA_SERVER_DEBUG) System.out.println("MediaServer auth succeeded");
+        }
         // There's only 4 commands we take.
         // 1 - OPEN filename
         // 2 - CLOSE


### PR DESCRIPTION
## Summary

- The MediaServer (port 7818) accepts connections with **zero authentication** — any network client can connect and issue file operation commands
- Adds optional shared-secret authentication: when `media_server_auth_key` is configured, clients must send the key as the first line before commands are accepted
- Re-enables the DoS protection that was commented out (`readTillPanic` counter), preventing memory exhaustion via oversized command lines

## Vulnerability Details

**CWE-306** (Missing Authentication for Critical Function)

`MediaServer.java:161-177` binds to `0.0.0.0:7818` and accepts connections in `Connection.run()` (line 981) with no authentication handshake. The server immediately processes commands including `OPEN` (file read), `WRITEOPEN` (file write), `LISTW`/`LISTRECURSIVEW` (directory listing), and `XCODE_SETUP` (transcoder initialization). While file access is gated by `checkFileAccess()`, the connection itself requires no credentials.

Additionally, the DoS protection at lines 357-360 was commented out, allowing unbounded input lines to consume server memory.

## Changes

- **Authentication gate**: After socket setup but before command processing, the server reads a line and compares it against `media_server_auth_key`. If the key matches, `OK` is sent and commands proceed. If it doesn't match, the connection is closed.
- **Backward compatibility**: When `media_server_auth_key` is empty (default), auth is skipped entirely — existing deployments continue to work without configuration changes.
- **DoS protection**: Uncommented the `readTillPanic` counter that limits individual command lines to `DOS_BYTE_LIMIT` (1MB).