### PR TITLE
Security: Restore password authentication for EncodingServer

### DIFF
--- a/java/sage/EncodingServer.java
+++ b/java/sage/EncodingServer.java
@@ -229,16 +229,24 @@ public class EncodingServer implements Runnable
         //mySock.setTcpNoDelay(true);
         outStream = new java.io.DataOutputStream(new java.io.BufferedOutputStream(mySock.getOutputStream()));
         inStream = new java.io.DataInputStream(new java.io.BufferedInputStream(mySock.getInputStream()));
-        /*				String pass = Sage.readLineBytes(inStream);
-				if (!pass.equalsIgnoreCase(Sage.get(ENCODING_SERVER_PASSWORD_MD5, "")))
-				{
-					outStream.write("INVALID_PASSWORD\r\n".getBytes(Sage.CHARSET));
-					outStream.flush();
-				}
-				else // valid password, accept the encoding command
-         */
-        //					outStream.write("OK\r\n".getBytes(Sage.CHARSET));
-        //					outStream.flush();
+        String configuredPass = Sage.get(ENCODING_SERVER_PASSWORD_MD5, "");
+        if (configuredPass.length() > 0)
+        {
+          String pass = Sage.readLineBytes(inStream);
+          if (!pass.equalsIgnoreCase(configuredPass))
+          {
+            outStream.write("INVALID_PASSWORD\r\n".getBytes(Sage.BYTE_CHARSET));
+            outStream.flush();
+            if (Sage.DBG) System.out.println("EncodingServer auth failed, closing connection from " + mySock);
+            return;
+          }
+          else
+          {
+            outStream.write("OK\r\n".getBytes(Sage.BYTE_CHARSET));
+            outStream.flush();
+            if (Sage.DBG) System.out.println("EncodingServer auth succeeded from " + mySock);
+          }
+        }
         while (true)
         {
           String str = Sage.readLineBytes(inStream);


### PR DESCRIPTION
## Summary

- The EncodingServer (port 6969) had its **entire password authentication block commented out** in the source code, allowing unauthenticated command execution
- Restores the original authentication logic and adds backward-compatible fallback when no password is configured

## Vulnerability Details

**CWE-306** (Missing Authentication for Critical Function)

`EncodingServer.java:232-241` contains a password authentication check wrapped in a `/* */` block comment, effectively disabling all authentication. The commented-out code was designed to check `ENCODING_SERVER_PASSWORD_MD5` against the client's password. Without it, any network client can connect and issue `START`, `STOP`, `TUNE`, `BUFFER`, and `SWITCH` commands to control encoding hardware and specify recording output file paths.

## Changes

- **Restored auth logic**: Removed the `/* */` block comment and `//` line comments to re-enable password checking
- **Backward compatibility**: When `ENCODING_SERVER_PASSWORD_MD5` is empty (default), auth is skipped — existing deployments without a configured password continue to work
- **Auth failure handling**: Invalid passwords trigger `INVALID_PASSWORD` response and connection close (via return from the handler, which triggers the finally block cleanup)
- **Charset fix**: Changed `Sage.CHARSET` to `Sage.BYTE_CHARSET` in auth response lines for consistency with the rest of the file