### PR TITLE
Security: Fix command injection in NFS mount check and CD burn status

### DIFF
--- a/java/sage/IOUtils.java
+++ b/java/sage/IOUtils.java
@@ -1143,8 +1143,9 @@ public class IOUtils
     if (!Sage.LINUX_OS) return NFS_MOUNT_FAILED;
     if (nfsPath.startsWith("nfs://"))
       nfsPath = nfsPath.substring(6);
-    // Check if the mount is already done
-    if (IOUtils.exec2(new String[] { "sh", "-c", "mount -t nfs | grep -i \"" + localPath  + "\"" }) == 0)
+    // Check if the mount is already done — avoid sh -c to prevent shell injection via localPath
+    String mountOutput = IOUtils.exec(new String[] { "mount", "-t", "nfs" });
+    if (mountOutput != null && mountOutput.toLowerCase().contains(localPath.toLowerCase()))
     {
       //if (Sage.DBG) System.out.println("NFS Mount already exists");
       return NFS_MOUNT_EXISTS;

--- a/java/sage/MediaFile.java
+++ b/java/sage/MediaFile.java
@@ -3685,7 +3685,8 @@ public class MediaFile extends DBObject implements SegmentedFile
         // It returns 0 if there's valid media in the drive (not blank either)
         String burnPath = Sage.get("linux/cd_burn", "cdrecord");
         String devPath = Sage.get("default_burner_device", "/dev/cdrom");
-        int rez = IOUtils.exec2(new String[] { "sh", "-c", burnPath + " -toc dev=" + devPath });
+        // Use array form to avoid shell injection via burnPath/devPath properties
+        int rez = IOUtils.exec2(new String[] { burnPath, "-toc", "dev=" + devPath });
         if (Sage.DBG) System.out.println("Checking DVD status rez: " + rez);
         return rez == 0;
       }


### PR DESCRIPTION
## Summary

- Two code paths pass configuration property values into `sh -c` shell commands, enabling command injection via `SetServerProperty` API
- Replaces shell-based execution with safe alternatives that don't interpret shell metacharacters

## Vulnerability Details

**CWE-78** (OS Command Injection)

Two code paths use `exec2(new String[]{"sh", "-c", ...})` with unsanitized property values concatenated into the command string:

1. **`IOUtils.java:1147`** — NFS mount check: `"mount -t nfs | grep -i \"" + localPath + "\""` — the `localPath` from `linux/nfs_mounts` property can escape the double quotes
2. **`MediaFile.java:3688`** — CD burn status: `burnPath + " -toc dev=" + devPath` — both `linux/cd_burn` and `default_burner_device` properties are concatenated directly

Since `SetServerProperty` (Configuration.java:831) allows any authenticated client to set any property with no validation, an attacker can inject shell metacharacters (`;`, `$()`) into these properties to execute arbitrary commands.

**Note:** Other code paths in `LinuxUtils.java` (gateway, SSID, WiFi key) use `exec2(String)` which calls `Runtime.exec(String)` — this tokenizes via `StringTokenizer` without invoking a shell, so those are NOT vulnerable to shell metacharacter injection.

## Changes

- **`IOUtils.java`**: Replaced `sh -c "mount | grep"` with running `mount -t nfs` via array exec and performing the case-insensitive match in Java. Eliminates the shell entirely.
- **`MediaFile.java`**: Replaced `sh -c` concatenation with the `String[]` array form of `exec2()`, which passes arguments directly to the OS without shell interpretation.